### PR TITLE
[API] 게시판 무한스크롤 목록 조회 API 구현

### DIFF
--- a/src/main/java/app/slicequeue/sq_board/board/command/domain/BoardId.java
+++ b/src/main/java/app/slicequeue/sq_board/board/command/domain/BoardId.java
@@ -55,8 +55,6 @@ public class BoardId {
 
     @Override
     public String toString() {
-        return "BoardId{" +
-                "id=" + id +
-                '}';
+        return String.valueOf(id);
     }
 }

--- a/src/main/java/app/slicequeue/sq_board/board/command/domain/BoardId.java
+++ b/src/main/java/app/slicequeue/sq_board/board/command/domain/BoardId.java
@@ -17,6 +17,8 @@ import java.util.Objects;
 @Embeddable
 public class BoardId {
 
+    static Snowflake snowflake = new Snowflake();
+
     @NotNull
     @Comment("게시판식별값")
     @Column(name = "board_id")
@@ -28,7 +30,6 @@ public class BoardId {
 
     public static BoardId generateId() {
         BoardId boardId = new BoardId();
-        Snowflake snowflake = new Snowflake();
         boardId.id = snowflake.nextId();
         return boardId;
     }

--- a/src/main/java/app/slicequeue/sq_board/board/command/presentation/BoardCommandController.java
+++ b/src/main/java/app/slicequeue/sq_board/board/command/presentation/BoardCommandController.java
@@ -20,16 +20,16 @@ public class BoardCommandController {
     private final UpdateBoardService updateBoardService;
 
     @PostMapping
-    public CommonResponse<Long> create(@RequestBody @Valid CreateBoardRequest request) {
+    public CommonResponse<String> create(@RequestBody @Valid CreateBoardRequest request) {
         CreateBoardCommand command = CreateBoardCommand.from(request);
-        return CommonResponse.success(createBoardService.createBoard(command).getId());
+        return CommonResponse.success("created.", createBoardService.createBoard(command).toString());
     }
 
     @PutMapping("/{boardId}")
-    public CommonResponse<Long> update(@PathVariable("boardId") Long boardId,
+    public CommonResponse<String> update(@PathVariable("boardId") Long boardId,
                                        @RequestBody @Valid UpdateBoardRequest request) {
         UpdateBoardCommand command = UpdateBoardCommand.of(boardId, request);
-        return CommonResponse.success(updateBoardService.updateBoard(command).getId());
+        return CommonResponse.success("updated.", updateBoardService.updateBoard(command).toString());
     }
 
 }

--- a/src/main/java/app/slicequeue/sq_board/board/query/application/dto/ReadAllByInfiniteScrollQuery.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/application/dto/ReadAllByInfiniteScrollQuery.java
@@ -2,7 +2,15 @@ package app.slicequeue.sq_board.board.query.application.dto;
 
 public record ReadAllByInfiniteScrollQuery(Long projectId, Long pageSize, Long lastBoardId) {
 
-    public static ReadAllByInfiniteScrollQuery of(Long projectId, Long pageSize, Long lastBoardId) {
-        return new ReadAllByInfiniteScrollQuery(projectId, pageSize, lastBoardId);
+    public static ReadAllByInfiniteScrollQuery of(Long projectId, Long pageSize, String lastBoardId) {
+        Long parsedLastBoardId = null;
+        if (lastBoardId != null) {
+            try {
+                parsedLastBoardId = Long.valueOf(lastBoardId);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("lastBoardId는 Long 타입이어야 합니다.");
+            }
+        }
+        return new ReadAllByInfiniteScrollQuery(projectId, pageSize, parsedLastBoardId);
     }
 }

--- a/src/main/java/app/slicequeue/sq_board/board/query/application/dto/ReadAllByInfiniteScrollQuery.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/application/dto/ReadAllByInfiniteScrollQuery.java
@@ -1,0 +1,8 @@
+package app.slicequeue.sq_board.board.query.application.dto;
+
+public record ReadAllByInfiniteScrollQuery(Long projectId, Long pageSize, Long lastBoardId) {
+
+    public static ReadAllByInfiniteScrollQuery of(Long projectId, Long pageSize, Long lastBoardId) {
+        return new ReadAllByInfiniteScrollQuery(projectId, pageSize, lastBoardId);
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/board/query/application/dto/ReadAllByPageQuery.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/application/dto/ReadAllByPageQuery.java
@@ -3,4 +3,8 @@ package app.slicequeue.sq_board.board.query.application.dto;
 import org.springframework.data.domain.Pageable;
 
 public record ReadAllByPageQuery(Long projectId, Pageable pageable) {
+
+    public static ReadAllByPageQuery of(Long projectId, Pageable pageable) {
+        return new ReadAllByPageQuery(projectId, pageable);
+    }
 }

--- a/src/main/java/app/slicequeue/sq_board/board/query/application/service/ReadAllBoardService.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/application/service/ReadAllBoardService.java
@@ -1,5 +1,6 @@
 package app.slicequeue.sq_board.board.query.application.service;
 
+import app.slicequeue.sq_board.board.query.application.dto.ReadAllByInfiniteScrollQuery;
 import app.slicequeue.sq_board.board.query.application.dto.ReadAllByPageQuery;
 import app.slicequeue.sq_board.board.query.infra.JpaBoardPagingQueryRepository;
 import app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem;
@@ -8,6 +9,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ReadAllBoardService {
@@ -15,13 +18,30 @@ public class ReadAllBoardService {
     JpaBoardPagingQueryRepository boardPagingQueryRepository;
 
     public Page<BoardListItem> readAll(ReadAllByPageQuery query) {
-        validateReadAllByPageQuery(query);
+        validateReadAllParam(query);
         return boardPagingQueryRepository.findAllBoardListItemsByProjectId(query.projectId(), query.pageable());
     }
 
-    private void validateReadAllByPageQuery(ReadAllByPageQuery query) {
+    private void validateReadAllParam(ReadAllByPageQuery query) {
         Assert.notNull(query, "query must not be null");
         Assert.notNull(query.projectId(), "projectId must not be null");
         Assert.notNull(query.pageable(), "pageable must not be null");
+    }
+
+    public List<BoardListItem> readAllInfiniteScroll(ReadAllByInfiniteScrollQuery query) {
+        validateReadAllInfiniteScrollParam(query);
+        if (query.lastBoardId() == null) {
+            return boardPagingQueryRepository.findAllBoardListItemsInfiniteScroll(query.projectId(), query.pageSize());
+        }
+        return boardPagingQueryRepository.findAllBoardListItemsInfiniteScroll(
+                query.projectId(),
+                query.pageSize(),
+                query.lastBoardId());
+    }
+
+    private void validateReadAllInfiniteScrollParam(ReadAllByInfiniteScrollQuery query) {
+        Assert.notNull(query, "query must not be null");
+        Assert.notNull(query.projectId(), "projectId must not be null");
+        Assert.notNull(query.pageSize(), "projectId must not be null");
     }
 }

--- a/src/main/java/app/slicequeue/sq_board/board/query/application/service/ReadAllBoardService.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/application/service/ReadAllBoardService.java
@@ -15,7 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ReadAllBoardService {
 
-    JpaBoardPagingQueryRepository boardPagingQueryRepository;
+    private final JpaBoardPagingQueryRepository boardPagingQueryRepository;
 
     public Page<BoardListItem> readAll(ReadAllByPageQuery query) {
         validateReadAllParam(query);

--- a/src/main/java/app/slicequeue/sq_board/board/query/infra/JpaBoardPagingQueryRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/infra/JpaBoardPagingQueryRepository.java
@@ -10,21 +10,54 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface JpaBoardPagingQueryRepository extends JpaRepository<Board, BoardId> {
 
     @Query("""
-        SELECT new app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem(
-            b.boardId.id,
-            b.name,
-            b.projectId,
-            b.adminId,
-            b.createdAt,
-            b.updatedAt
-        )
-        FROM Board b
-        WHERE b.projectId = :projectId
-    """)
+                SELECT new app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem(
+                    b.boardId.id,
+                    b.name,
+                    b.projectId,
+                    b.adminId,
+                    b.createdAt,
+                    b.updatedAt
+                )
+                FROM Board b
+                WHERE b.projectId = :projectId
+            """)
     Page<BoardListItem> findAllBoardListItemsByProjectId(@Param("projectId") Long projectId, Pageable pageable);
+
+    @Query("""
+            SELECT new app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem(
+                b.boardId.id,
+                b.name,
+                b.projectId,
+                b.adminId,
+                b.createdAt,
+                b.updatedAt
+            )
+            FROM Board b
+            WHERE b.projectId = :projectId
+            ORDER BY b.boardId.id desc LIMIT :pageSize
+                """)
+    List<BoardListItem> findAllBoardListItemsInfiniteScroll(Long projectId, Long pageSize);
+
+    @Query("""
+           SELECT new app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem(
+                b.boardId.id,
+                b.name,
+                b.projectId,
+                b.adminId,
+                b.createdAt,
+                b.updatedAt
+            )
+            FROM Board b
+            WHERE b.projectId = :projectId
+                  AND b.boardId.id < :lastBoardId
+            ORDER BY b.boardId.id desc LIMIT :pageSize
+            """)
+    List<BoardListItem> findAllBoardListItemsInfiniteScroll(Long projectId, Long pageSize, Long lastBoardId);
 
 }

--- a/src/main/java/app/slicequeue/sq_board/board/query/presentation/BoardQueryController.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/presentation/BoardQueryController.java
@@ -1,17 +1,21 @@
 package app.slicequeue.sq_board.board.query.presentation;
 
 import app.slicequeue.common.dto.CommonResponse;
+import app.slicequeue.sq_board.board.query.application.dto.ReadAllByInfiniteScrollQuery;
 import app.slicequeue.sq_board.board.query.application.dto.ReadAllByPageQuery;
 import app.slicequeue.sq_board.board.query.application.service.ReadAllBoardService;
 import app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/boards")
@@ -23,8 +27,18 @@ public class BoardQueryController {
     @GetMapping
     public CommonResponse<Page<BoardListItem>> readAll(
             @RequestParam("projectId") Long projectId, @PageableDefault(sort = "createdAt,desc") Pageable pageable) {
-        ReadAllByPageQuery query = new ReadAllByPageQuery(projectId, pageable);
+        ReadAllByPageQuery query = ReadAllByPageQuery.of(projectId, pageable);
         Page<BoardListItem> all = readAllBoardService.readAll(query);
+        return CommonResponse.success(all);
+    }
+
+    @GetMapping("/infinite-scroll")
+    public CommonResponse<List<BoardListItem>> readAllInfiniteScroll(@RequestParam("projectId") Long projectId,
+                                                                     @RequestParam(value = "size", defaultValue =
+                                                                             "10") Long pageSize,
+                                                                     @RequestParam(value = "lastBoardId", required = false) Long lastBoardId) {
+        ReadAllByInfiniteScrollQuery query = ReadAllByInfiniteScrollQuery.of(projectId, pageSize, lastBoardId);
+        List<BoardListItem> all = readAllBoardService.readAllInfiniteScroll(query);
         return CommonResponse.success(all);
     }
 }

--- a/src/main/java/app/slicequeue/sq_board/board/query/presentation/BoardQueryController.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/presentation/BoardQueryController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,17 +27,18 @@ public class BoardQueryController {
 
     @GetMapping
     public CommonResponse<Page<BoardListItem>> readAll(
-            @RequestParam("projectId") Long projectId, @PageableDefault(sort = "createdAt,desc") Pageable pageable) {
+            @RequestParam("projectId") Long projectId,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         ReadAllByPageQuery query = ReadAllByPageQuery.of(projectId, pageable);
         Page<BoardListItem> all = readAllBoardService.readAll(query);
         return CommonResponse.success(all);
     }
 
     @GetMapping("/infinite-scroll")
-    public CommonResponse<List<BoardListItem>> readAllInfiniteScroll(@RequestParam("projectId") Long projectId,
-                                                                     @RequestParam(value = "size", defaultValue =
-                                                                             "10") Long pageSize,
-                                                                     @RequestParam(value = "lastBoardId", required = false) Long lastBoardId) {
+    public CommonResponse<List<BoardListItem>> readAllInfiniteScroll(
+            @RequestParam("projectId") Long projectId,
+            @RequestParam(value = "size", required = false, defaultValue = "10") Long pageSize,
+            @RequestParam(value = "lastBoardId", required = false) String lastBoardId) {
         ReadAllByInfiniteScrollQuery query = ReadAllByInfiniteScrollQuery.of(projectId, pageSize, lastBoardId);
         List<BoardListItem> all = readAllBoardService.readAllInfiniteScroll(query);
         return CommonResponse.success(all);

--- a/src/test/java/app/slicequeue/sq_board/board/query/application/service/ReadAllBoardServiceTest.java
+++ b/src/test/java/app/slicequeue/sq_board/board/query/application/service/ReadAllBoardServiceTest.java
@@ -81,7 +81,7 @@ class ReadAllBoardServiceTest {
 
     void 마지막위치가_있는_무한스크롤_조회쿼리를_통해_첫위치_게시글을_복수조회한다() {
         // given
-        ReadAllByInfiniteScrollQuery query = ReadAllByInfiniteScrollQuery.of(1L, 10L, 123L);
+        ReadAllByInfiniteScrollQuery query = ReadAllByInfiniteScrollQuery.of(1L, 10L, "123");
 
         // when
         readAllBoardService.readAllInfiniteScroll(query);

--- a/src/test/java/app/slicequeue/sq_board/board/query/infra/JpaBoardPagingQueryRepositoryTest.java
+++ b/src/test/java/app/slicequeue/sq_board/board/query/infra/JpaBoardPagingQueryRepositoryTest.java
@@ -1,9 +1,12 @@
 package app.slicequeue.sq_board.board.query.infra;
 
-import app.slicequeue.sq_board.board.command.domain.Board;
 import app.slicequeue.sq_board.board.BoardTestFixture;
+import app.slicequeue.sq_board.board.command.domain.Board;
+import app.slicequeue.sq_board.board.command.domain.BoardId;
 import app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -31,15 +34,20 @@ class JpaBoardPagingQueryRepositoryTest {
 
     @BeforeEach
     void init() {
-        List<Board> boards = BoardTestFixture.createBoardExamples(10, mockProjectId, mockAdminId);
-        for (Board board : boards) {
+        List<Board> boardList = BoardTestFixture.createBoardExamples(10, mockProjectId, mockAdminId);
+        for (Board board : boardList) {
             jpaBoardPagingQueryRepository.saveAndFlush(board);
         }
     }
 
+    @AfterEach
+    void clear() {
+        jpaBoardPagingQueryRepository.deleteAll();
+    }
+
     @ParameterizedTest
     @MethodSource("pagingArguments")
-    void 페이징인자를_통해_복수조회를_한다(int pageNumber, int pageSize, int expectedCount) {
+    void 페이징인자를_통해_페이징복수조회를_한다(int pageNumber, int pageSize, int expectedCount) {
         // given
         PageRequest page = PageRequest.of(pageNumber, pageSize, Sort.by(DESC, "createdAt"));
         Long projectId = mockProjectId;
@@ -61,4 +69,40 @@ class JpaBoardPagingQueryRepositoryTest {
         );
     }
 
+    @Test
+    void 무한스크롤인자를_통해_무한스크롤복수조회를_한다() {
+        // given
+        Long projectId = mockProjectId;
+        long pageSize = 3;
+        List<Board> all =
+                jpaBoardPagingQueryRepository.findAll().stream()
+                        .sorted(Comparator.comparing(Board::getCreatedAt).reversed()).toList();
+
+        // when
+        List<BoardListItem> results1 = jpaBoardPagingQueryRepository.findAllBoardListItemsInfiniteScroll(projectId,
+                pageSize);
+        List<BoardListItem> results2 = jpaBoardPagingQueryRepository.findAllBoardListItemsInfiniteScroll(projectId,
+                pageSize, Long.valueOf(results1.getLast().getBoardId()));
+        List<BoardListItem> results3 = jpaBoardPagingQueryRepository.findAllBoardListItemsInfiniteScroll(projectId,
+                pageSize, Long.valueOf(results2.getLast().getBoardId()));
+        List<BoardListItem> results4 = jpaBoardPagingQueryRepository.findAllBoardListItemsInfiniteScroll(projectId,
+                pageSize, Long.valueOf(results3.getLast().getBoardId()));
+        List<BoardListItem> results5 = jpaBoardPagingQueryRepository.findAllBoardListItemsInfiniteScroll(projectId,
+                pageSize, Long.valueOf(results4.getLast().getBoardId()));
+
+        // then
+        assertThat(results1).hasSize((int) pageSize);
+        assertThat(results2).hasSize((int) pageSize);
+        assertThat(results3).hasSize((int) pageSize);
+        assertThat(results4).hasSize(1);
+        assertThat(results5).isEmpty();
+
+        BoardId expectedFirstBoardId = all.getFirst().getBoardId();
+        BoardId expectedLastBoardId = all.getLast().getBoardId();
+        assertThat(results1.getFirst().getBoardId()).isEqualTo(String.valueOf(expectedFirstBoardId.getId()));
+        assertThat(results4.getLast().getBoardId()).isEqualTo(String.valueOf(expectedLastBoardId.getId()));
+
+        assertThat(Stream.concat(Stream.concat(Stream.concat(results1.stream(), results2.stream()), results3.stream()),
+                results4.stream())).isSortedAccordingTo(Comparator.comparing(BoardListItem::getBoardId).reversed());
+    }
 }


### PR DESCRIPTION
## 🛠️ 목적
게시판 무한스크롤 API를 구현하여 클라이언트가 데이터를 페이지 단위로 효율적으로 조회할 수 있도록 개선합니다.

## 📄 내용 요약
- 게시판 무한스크롤 목록 조회 API를 구현했습니다.
- API를 통해 클라이언트에서 무한스크롤 조회 처리가 용이하도록 데이터를 제공할 수 있도록 설계하였습니다.

## ✨ 주요 변경 사항
1. **API 엔드포인트**  
   - 새로운 엔드포인트를 추가하여 게시판 데이터를 무한스크롤 마지막 위치로 조회할 수 있도록 구현.
   - API 요청 시 프로젝트 식별값과 마지막 보드 식별값 위치와 데이터 수를 파라미터로 받을 수 있도록 설계.
   
2. **로직 구현**  
   - 데이터베이스에서 페이징 처리를 위한 쿼리 로직 추가.
   - 요청받은 프로젝트 식별값과 마지막 보드 식별값 위치와 데이터 수에 따라 필요한 데이터만 반환하는 기능 구현.

3. **테스트**  
   - 유닛 테스트 및 통합 테스트를 추가하여 API가 정상적으로 작동하는지 검증.
   - 다양한 무한스크롤 페이징 시나리오를 테스트하여 안정성을 확보.

## 🚀 적용 방법
1. 클라이언트에서 프로젝트 식별값과 마지막 보드 식별값 위치와 데이터 수를 포함한 요청을 전송합니다.
2. 해당 API 엔드포인트를 호출하여 필요한 프로젝트의 게시판 보드 위치, 데이터 수 단위로 받아옵니다.
3. 클라이언트에서 받은 데이터를 화면에 렌더링하여 페이징 UI를 구성합니다.

## ✅ 체크리스트
- [ ] API 엔드포인트가 정상적으로 호출되는지 확인
- [x] 무한스크롤 로직이 정확히 작동하는지 테스트
- [x] 다양한 페이지 요청 시 데이터가 올바르게 반환되는지 검증
- [x] 관련 코드가 코드 리뷰 기준에 부합하는지 확인
