### PR TITLE
[API] 게시판 상세 조회 API 구현

### DIFF
--- a/src/main/java/app/slicequeue/sq_board/board/query/application/dto/ReadDetailQuery.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/application/dto/ReadDetailQuery.java
@@ -1,0 +1,10 @@
+package app.slicequeue.sq_board.board.query.application.dto;
+
+import app.slicequeue.sq_board.board.command.domain.BoardId;
+
+public record ReadDetailQuery(Long projectId, BoardId boardId) {
+
+    public static ReadDetailQuery of(Long projectId, Long boardId) {
+        return new ReadDetailQuery(projectId, BoardId.from(boardId));
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/board/query/application/service/ReadDetailBoardService.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/application/service/ReadDetailBoardService.java
@@ -1,0 +1,31 @@
+package app.slicequeue.sq_board.board.query.application.service;
+
+import app.slicequeue.common.exception.NotFoundException;
+import app.slicequeue.sq_board.board.query.application.dto.ReadDetailQuery;
+import app.slicequeue.sq_board.board.query.infra.JpaBoardPagingQueryRepository;
+import app.slicequeue.sq_board.board.query.presentation.dto.BoardDetail;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ReadDetailBoardService {
+
+    private final JpaBoardPagingQueryRepository boardPagingQueryRepository;
+
+    public BoardDetail readDetail(ReadDetailQuery query) {
+        validateReadDetailParam(query);
+        return boardPagingQueryRepository.findBoardDetailBy(query.projectId(), query.boardId().getId())
+                .orElseThrow(() -> new NotFoundException(String.format("board not found. %s", query)));
+    }
+
+    private static void validateReadDetailParam(ReadDetailQuery query) {
+        Assert.notNull(query, "query must not be null.");
+        Assert.notNull(query.projectId(), "projectId must not be null.");
+        Assert.notNull(query.boardId(), "boardId must not be null.");
+    }
+
+}

--- a/src/main/java/app/slicequeue/sq_board/board/query/infra/JpaBoardPagingQueryRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/infra/JpaBoardPagingQueryRepository.java
@@ -2,6 +2,7 @@ package app.slicequeue.sq_board.board.query.infra;
 
 import app.slicequeue.sq_board.board.command.domain.Board;
 import app.slicequeue.sq_board.board.command.domain.BoardId;
+import app.slicequeue.sq_board.board.query.presentation.dto.BoardDetail;
 import app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,9 +12,11 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface JpaBoardPagingQueryRepository extends JpaRepository<Board, BoardId> {
+
 
     @Query("""
                 SELECT new app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem(
@@ -59,5 +62,22 @@ public interface JpaBoardPagingQueryRepository extends JpaRepository<Board, Boar
             ORDER BY b.boardId.id desc LIMIT :pageSize
             """)
     List<BoardListItem> findAllBoardListItemsInfiniteScroll(Long projectId, Long pageSize, Long lastBoardId);
+
+
+    @Query("""
+            SELECT new app.slicequeue.sq_board.board.query.presentation.dto.BoardDetail(
+                    b.boardId.id,
+                    b.name,
+                    b.description,
+                    b.projectId,
+                    b.adminId,
+                    b.createdAt,
+                    b.updatedAt
+                )
+                FROM Board b
+                WHERE b.projectId = :projectId AND b.boardId.id = :boardId
+            """)
+    Optional<BoardDetail> findBoardDetailBy(@Param("projectId") Long projectId,
+                                            @Param("boardId") Long boardId);
 
 }

--- a/src/main/java/app/slicequeue/sq_board/board/query/presentation/BoardQueryController.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/presentation/BoardQueryController.java
@@ -3,18 +3,19 @@ package app.slicequeue.sq_board.board.query.presentation;
 import app.slicequeue.common.dto.CommonResponse;
 import app.slicequeue.sq_board.board.query.application.dto.ReadAllByInfiniteScrollQuery;
 import app.slicequeue.sq_board.board.query.application.dto.ReadAllByPageQuery;
+import app.slicequeue.sq_board.board.query.application.dto.ReadDetailQuery;
 import app.slicequeue.sq_board.board.query.application.service.ReadAllBoardService;
+import app.slicequeue.sq_board.board.query.application.service.ReadDetailBoardService;
+import app.slicequeue.sq_board.board.query.presentation.dto.BoardDetail;
 import app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -24,6 +25,7 @@ import java.util.List;
 public class BoardQueryController {
 
     private final ReadAllBoardService readAllBoardService;
+    private final ReadDetailBoardService readDetailBoardService;
 
     @GetMapping
     public CommonResponse<Page<BoardListItem>> readAll(
@@ -42,5 +44,14 @@ public class BoardQueryController {
         ReadAllByInfiniteScrollQuery query = ReadAllByInfiniteScrollQuery.of(projectId, pageSize, lastBoardId);
         List<BoardListItem> all = readAllBoardService.readAllInfiniteScroll(query);
         return CommonResponse.success(all);
+    }
+
+    @GetMapping("/{boardId}")
+    public CommonResponse<BoardDetail> readDetail(
+            @RequestParam("projectId") Long projectId,
+            @PathVariable("boardId") Long boardId) {
+        ReadDetailQuery query = ReadDetailQuery.of(projectId, boardId);
+        BoardDetail detail = readDetailBoardService.readDetail(query);
+        return CommonResponse.success(detail);
     }
 }

--- a/src/main/java/app/slicequeue/sq_board/board/query/presentation/dto/BoardDetail.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/presentation/dto/BoardDetail.java
@@ -1,0 +1,51 @@
+package app.slicequeue.sq_board.board.query.presentation.dto;
+
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+public class BoardDetail {
+
+    private final String boardId;
+    private final String name;
+    private final String description;
+    private final String projectId;
+    private final String adminId;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public BoardDetail(
+            String boardId,
+            String name,
+            String description,
+            String projectId,
+            String adminId,
+            Instant createdAt,
+            Instant updatedAt) {
+        this.boardId = boardId;
+        this.name = name;
+        this.description = description;
+        this.projectId = projectId;
+        this.adminId = adminId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public BoardDetail(
+            Long boardId,
+            String name,
+            String description,
+            Long projectId,
+            Long adminId,
+            Instant createdAt,
+            Instant updatedAt) {
+        this(String.valueOf(boardId),
+                name,
+                description,
+                String.valueOf(projectId),
+                String.valueOf(adminId),
+                createdAt,
+                updatedAt);
+    }
+}

--- a/src/test/java/app/slicequeue/sq_board/board/query/application/service/ReadAllBoardServiceTest.java
+++ b/src/test/java/app/slicequeue/sq_board/board/query/application/service/ReadAllBoardServiceTest.java
@@ -1,11 +1,8 @@
 package app.slicequeue.sq_board.board.query.application.service;
 
-import app.slicequeue.sq_board.board.BoardTestFixture;
 import app.slicequeue.sq_board.board.query.application.dto.ReadAllByInfiniteScrollQuery;
 import app.slicequeue.sq_board.board.query.application.dto.ReadAllByPageQuery;
 import app.slicequeue.sq_board.board.query.infra.JpaBoardPagingQueryRepository;
-import app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,16 +11,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
-import java.util.List;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -93,8 +85,7 @@ class ReadAllBoardServiceTest {
 
     @ParameterizedTest
     @MethodSource("invalidReadAllByInfiniteScrollQueries")
-    void 비정상_무한스크롤_조회쿼리를_통해_예외가발생한다(ReadAllByInfiniteScrollQuery query) {
-        // given
+    void 비정상_무한스크롤_조회쿼리를_통해_예외가발생한다(ReadAllByInfiniteScrollQuery query) { // given
 
         // when & then
         assertThatThrownBy(() -> readAllBoardService.readAllInfiniteScroll(query))

--- a/src/test/java/app/slicequeue/sq_board/board/query/application/service/ReadDetailBoardServiceTest.java
+++ b/src/test/java/app/slicequeue/sq_board/board/query/application/service/ReadDetailBoardServiceTest.java
@@ -1,0 +1,81 @@
+package app.slicequeue.sq_board.board.query.application.service;
+
+import app.slicequeue.common.exception.NotFoundException;
+import app.slicequeue.sq_board.board.command.domain.BoardId;
+import app.slicequeue.sq_board.board.query.application.dto.ReadDetailQuery;
+import app.slicequeue.sq_board.board.query.infra.JpaBoardPagingQueryRepository;
+import app.slicequeue.sq_board.board.query.presentation.dto.BoardDetail;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@TestMethodOrder(MethodName.class)
+@ExtendWith(MockitoExtension.class)
+class ReadDetailBoardServiceTest {
+
+    @InjectMocks
+    ReadDetailBoardService readDetailBoardService;
+
+    @Mock
+    JpaBoardPagingQueryRepository boardPagingQueryRepository;
+
+
+    @Test
+    void 상세조회쿼리를_통해_게시글을_조회한다() {
+        // given
+        ReadDetailQuery query = new ReadDetailQuery(1L, BoardId.from(1L));
+        given(boardPagingQueryRepository.findBoardDetailBy(query.projectId(), query.boardId().getId())).willReturn(Optional.of(Mockito.mock(BoardDetail.class)));
+
+        // when
+        readDetailBoardService.readDetail(query);
+
+        // then
+        verify(boardPagingQueryRepository, times(1))
+                .findBoardDetailBy(query.projectId(), query.boardId().getId());
+    }
+
+    @Test
+    void 상세조회쿼리를_통해_게시글을_조회를_했으나_없는경우_NotFoundException_예외가_발생한다() {
+        // given
+        ReadDetailQuery query = new ReadDetailQuery(1L, BoardId.from(1L));
+        given(boardPagingQueryRepository.findBoardDetailBy(query.projectId(), query.boardId().getId())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> readDetailBoardService.readDetail(query)).isInstanceOf(NotFoundException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidReadDetailQueries")
+    void 비정상상세조회쿼리를_통해_게시글을_조회시_예외가_발생한다(ReadDetailQuery query) { // given
+
+        // when & then
+        assertThatThrownBy(() -> readDetailBoardService.readDetail(query))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    public static Stream<Arguments> invalidReadDetailQueries() {
+        return Stream.of(
+                Arguments.of((Object) null),
+                Arguments.of(ReadDetailQuery.of(null, null)),
+                Arguments.of(ReadDetailQuery.of(1L, null)),
+                Arguments.of(ReadDetailQuery.of(null, 1L))
+        );
+    }
+}

--- a/src/test/java/app/slicequeue/sq_board/board/query/infra/JpaBoardPagingQueryRepositoryTest.java
+++ b/src/test/java/app/slicequeue/sq_board/board/query/infra/JpaBoardPagingQueryRepositoryTest.java
@@ -3,6 +3,7 @@ package app.slicequeue.sq_board.board.query.infra;
 import app.slicequeue.sq_board.board.BoardTestFixture;
 import app.slicequeue.sq_board.board.command.domain.Board;
 import app.slicequeue.sq_board.board.command.domain.BoardId;
+import app.slicequeue.sq_board.board.query.presentation.dto.BoardDetail;
 import app.slicequeue.sq_board.board.query.presentation.dto.BoardListItem;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.Sort;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,5 +106,35 @@ class JpaBoardPagingQueryRepositoryTest {
 
         assertThat(Stream.concat(Stream.concat(Stream.concat(results1.stream(), results2.stream()), results3.stream()),
                 results4.stream())).isSortedAccordingTo(Comparator.comparing(BoardListItem::getBoardId).reversed());
+    }
+
+    @Test
+    void 프로젝트식별값과_게시판식별값을_통해_게시판_단건상세조회를한다_있는_경우_옵셔널객체() {
+        // given
+        Long projectId = mockProjectId;
+        List<Board> all =
+                jpaBoardPagingQueryRepository.findAll().stream()
+                        .sorted(Comparator.comparing(Board::getCreatedAt).reversed()).toList();
+        BoardId boardId = all.getFirst().getBoardId();
+
+        // when
+        Optional<BoardDetail> result = jpaBoardPagingQueryRepository.findBoardDetailBy(projectId, boardId.getId());
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getBoardId()).isEqualTo(boardId.toString());
+    }
+
+    @Test
+    void 프로젝트식별값과_게시판식별값을_통해_게시판_단건상세조회를한다_없는_경우_빈옵셔널객체() {
+        // given
+        Long projectId = mockProjectId;
+        Long wrongBoardId = Long.MAX_VALUE;
+
+        // when
+        Optional<BoardDetail> result = jpaBoardPagingQueryRepository.findBoardDetailBy(projectId, wrongBoardId);
+
+        // then
+        assertThat(result).isEmpty();
     }
 }


### PR DESCRIPTION
## 🛠️ 목적
게시판 상세 조회 API를 구현하여 클라이언트가 게시글 상세 조회할 수 있도록 합니다.

## 📄 내용 요약
- 게시판 상세 조회 API를 구현했습니다.

## ✨ 주요 변경 사항
1. **API 엔드포인트**  
   - 새로운 엔드포인트를 추가하여 게시판 데이터를 단건 상세 조회할 수 있도록 구현.
   - API 요청 시 프로젝트 id, 게시판 id 파라미터로 받을 수 있도록 설계.
   
2. **로직 구현**  
   - 데이터베이스에서 단건 조회 처리를 위한 쿼리 로직 추가.
   - 요청받은 프로젝트 id, 게시판 id에 따라 필요한 데이터만 반환하는 기능 구현.

3. **테스트**  
   - 유닛 테스트 및 통합 테스트를 추가하여 API가 정상적으로 작동하는지 검증.
   - 다양한 시나리오를 테스트하여 안정성을 확보.

## 🚀 적용 방법
1. 클라이언트에서 페이지 번호와 데이터 수를 포함한 요청을 전송합니다.
2. 해당 API 엔드포인트를 호출하여 필요한 데이터만 페이지 단위로 받아옵니다.
3. 클라이언트에서 받은 데이터를 화면에 렌더링하여 게시판 단건 상세 조회 UI를 구성합니다.

## ✅ 체크리스트
- [ ] API 엔드포인트가 정상적으로 호출되는지 확인
- [ ] 게시판 단건 상세 조회 로직이 정확히 작동하는지 테스트
- [ ] 다양한 요청 시 데이터가 올바르게 반환되는지 검증
- [ ] 관련 코드가 코드 리뷰 기준에 부합하는지 확인
