### PR TITLE
[API] 게시글 생성/수정/삭제 API 구현

### DIFF
--- a/src/main/java/app/slicequeue/sq_board/article/command/application/CreateArticleService.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/application/CreateArticleService.java
@@ -1,0 +1,21 @@
+package app.slicequeue.sq_board.article.command.application;
+
+import app.slicequeue.sq_board.article.command.domain.Article;
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import app.slicequeue.sq_board.article.command.domain.ArticleRepository;
+import app.slicequeue.sq_board.article.command.domain.dto.CreateArticleCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    public ArticleId createArticle(CreateArticleCommand command) {
+        Article article = Article.create(command);
+        Article save = articleRepository.save(article);
+        return save.getArticleId();
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/article/command/application/DeleteArticleService.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/application/DeleteArticleService.java
@@ -4,6 +4,7 @@ import app.slicequeue.common.exception.NotFoundException;
 import app.slicequeue.sq_board.article.command.domain.Article;
 import app.slicequeue.sq_board.article.command.domain.ArticleId;
 import app.slicequeue.sq_board.article.command.domain.ArticleRepository;
+import app.slicequeue.sq_board.article.command.domain.dto.DeleteArticleCommand;
 import app.slicequeue.sq_board.article.command.domain.dto.UpdateArticleCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,15 +13,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class UpdateArticleService {
+public class DeleteArticleService {
 
     private final ArticleRepository articleRepository;
 
-    public ArticleId updateArticle(UpdateArticleCommand command) {
+    public ArticleId deleteArticle(DeleteArticleCommand command) {
         Article article = articleRepository.findByArticleIdAndDeletedAtIsNull(command.articleId())
                 .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다."));
-        article.update(command);
-        Article save = articleRepository.save(article);
-        return save.getArticleId();
+        article.delete();
+        articleRepository.save(article);
+        return article.getArticleId();
     }
 }

--- a/src/main/java/app/slicequeue/sq_board/article/command/application/UpdateArticleService.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/application/UpdateArticleService.java
@@ -1,9 +1,10 @@
 package app.slicequeue.sq_board.article.command.application;
 
+import app.slicequeue.common.exception.NotFoundException;
 import app.slicequeue.sq_board.article.command.domain.Article;
 import app.slicequeue.sq_board.article.command.domain.ArticleId;
 import app.slicequeue.sq_board.article.command.domain.ArticleRepository;
-import app.slicequeue.sq_board.article.command.domain.dto.CreateArticleCommand;
+import app.slicequeue.sq_board.article.command.domain.dto.UpdateArticleCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,12 +12,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class CreateArticleService {
+public class UpdateArticleService {
 
     private final ArticleRepository articleRepository;
 
-    public ArticleId createArticle(CreateArticleCommand command) {
-        Article article = Article.create(command);
+    public ArticleId updateArticle(UpdateArticleCommand command) {
+        Article article = articleRepository.findByArticleId(command.articleId())
+                .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다."));
+        article.update(command);
         Article save = articleRepository.save(article);
         return save.getArticleId();
     }

--- a/src/main/java/app/slicequeue/sq_board/article/command/domain/Article.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/domain/Article.java
@@ -1,0 +1,59 @@
+package app.slicequeue.sq_board.article.command.domain;
+
+import app.slicequeue.common.base.time_entity.BaseTimeSoftDeleteEntity;
+import app.slicequeue.sq_board.article.command.domain.dto.CreateArticleCommand;
+import app.slicequeue.sq_board.board.command.domain.BoardId;
+import app.slicequeue.sq_board.common.util.StringListConverter;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Table(name = "article", indexes = {
+        @Index(name = "idx_board_id_article_id", columnList = "board_id,article_id desc")})
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Article extends BaseTimeSoftDeleteEntity {
+
+    @EmbeddedId
+    private ArticleId articleId;
+
+    @NotNull(message = "boardId must not be null")
+    private BoardId boardId; // shard key
+
+    @Size(min = 1, max = 200)
+    @NotNull(message = "title must not be null")
+    private String title;
+
+    @NotNull(message = "writerId must not be null")
+    private Long writerId;
+
+    @NotNull(message = "writerName must not be null")
+    private String writerName;
+
+    @Column(columnDefinition = "TEXT NOT NULL") // 최대 길이 65,535자 (단, 영문 기준! 한글 및 이모지 포함시 더 줄어듦)
+    @Size(min = 1, max = 20000) // 따라서 길이 제한 20000 으로
+    @NotNull(message = "content must not be null")
+    private String content;
+
+    @Convert(converter = StringListConverter.class)
+    private List<String> tags; // TODO 추후 태그 최적화를 위해 M:N 맵핑 처리 진행할 것
+
+    public static Article create(CreateArticleCommand command) {
+        Article article = new Article();
+        article.boardId = command.boardId();
+        article.title = command.title();
+        article.writerId = command.writerId();
+        article.writerName = command.writerName();
+        article.content = command.content();
+        article.tags = command.tags();
+
+        article.articleId = ArticleId.generateId();
+        return article;
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/article/command/domain/Article.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/domain/Article.java
@@ -2,6 +2,7 @@ package app.slicequeue.sq_board.article.command.domain;
 
 import app.slicequeue.common.base.time_entity.BaseTimeSoftDeleteEntity;
 import app.slicequeue.sq_board.article.command.domain.dto.CreateArticleCommand;
+import app.slicequeue.sq_board.article.command.domain.dto.UpdateArticleCommand;
 import app.slicequeue.sq_board.board.command.domain.BoardId;
 import app.slicequeue.sq_board.common.util.StringListConverter;
 import jakarta.persistence.*;
@@ -55,5 +56,11 @@ public class Article extends BaseTimeSoftDeleteEntity {
 
         article.articleId = ArticleId.generateId();
         return article;
+    }
+
+    public void update(UpdateArticleCommand command) {
+        this.title = command.title();
+        this.content = command.content();
+        this.tags = command.tags();
     }
 }

--- a/src/main/java/app/slicequeue/sq_board/article/command/domain/Article.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/domain/Article.java
@@ -63,4 +63,8 @@ public class Article extends BaseTimeSoftDeleteEntity {
         this.content = command.content();
         this.tags = command.tags();
     }
+
+    public void delete() {
+        nowDeletedAt();
+    }
 }

--- a/src/main/java/app/slicequeue/sq_board/article/command/domain/ArticleId.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/domain/ArticleId.java
@@ -1,0 +1,60 @@
+package app.slicequeue.sq_board.article.command.domain;
+
+import app.slicequeue.common.snowflake.Snowflake;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.springframework.util.Assert;
+
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class ArticleId {
+
+    static Snowflake snowflake = new Snowflake();
+
+    @NotNull
+    @Comment("게시글식별값")
+    @Column(name = "article_id")
+    private Long id;
+
+    public ArticleId(Long id) {
+        this.id = id;
+    }
+
+    public static ArticleId generateId() {
+        ArticleId articleId = new ArticleId();
+        articleId.id = snowflake.nextId();
+        return articleId;
+    }
+
+    public static ArticleId from(Long idValue) {
+        Assert.notNull(idValue, "id must not be null");
+        if (idValue <= 0)
+            throw new IllegalArgumentException("id must be positive value");
+        return new ArticleId(idValue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ArticleId articleId)) return false;
+        return Objects.equals(getId(), articleId.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(id);
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/article/command/domain/ArticleRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/domain/ArticleRepository.java
@@ -2,8 +2,12 @@ package app.slicequeue.sq_board.article.command.domain;
 
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ArticleRepository {
 
     Article save(Article board);
+
+    Optional<Article> findByArticleId(ArticleId articleId);
 }

--- a/src/main/java/app/slicequeue/sq_board/article/command/domain/ArticleRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/domain/ArticleRepository.java
@@ -9,5 +9,5 @@ public interface ArticleRepository {
 
     Article save(Article board);
 
-    Optional<Article> findByArticleId(ArticleId articleId);
+    Optional<Article> findByArticleIdAndDeletedAtIsNull(ArticleId articleId);
 }

--- a/src/main/java/app/slicequeue/sq_board/article/command/domain/ArticleRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/domain/ArticleRepository.java
@@ -1,0 +1,9 @@
+package app.slicequeue.sq_board.article.command.domain;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArticleRepository {
+
+    Article save(Article board);
+}

--- a/src/main/java/app/slicequeue/sq_board/article/command/domain/dto/CreateArticleCommand.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/domain/dto/CreateArticleCommand.java
@@ -1,0 +1,28 @@
+package app.slicequeue.sq_board.article.command.domain.dto;
+
+import app.slicequeue.sq_board.article.command.presentation.dto.CreateArticleRequest;
+import app.slicequeue.sq_board.board.command.domain.BoardId;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CreateArticleCommand(
+        BoardId boardId,
+        String title,
+        String content,
+        List<String> tags,
+        Long writerId,
+        String writerName) {
+
+    public static CreateArticleCommand from(CreateArticleRequest request) {
+
+        return new CreateArticleCommand(
+                BoardId.from(Long.valueOf(request.getBoardId())),
+                request.getTitle(),
+                request.getContent(),
+                request.getTags(),
+                Long.valueOf(request.getWriterId()),
+                request.getWriterName());
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/article/command/domain/dto/DeleteArticleCommand.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/domain/dto/DeleteArticleCommand.java
@@ -1,0 +1,9 @@
+package app.slicequeue.sq_board.article.command.domain.dto;
+
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+
+public record DeleteArticleCommand(ArticleId articleId) {
+    public static DeleteArticleCommand from(Long articleId) {
+        return new DeleteArticleCommand(ArticleId.from(articleId));
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/article/command/domain/dto/UpdateArticleCommand.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/domain/dto/UpdateArticleCommand.java
@@ -1,0 +1,24 @@
+package app.slicequeue.sq_board.article.command.domain.dto;
+
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import app.slicequeue.sq_board.article.command.presentation.dto.UpdateArticleRequest;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record UpdateArticleCommand(
+        ArticleId articleId,
+        String title,
+        String content,
+        List<String> tags) {
+
+    public static UpdateArticleCommand from(ArticleId articleId, UpdateArticleRequest request) {
+
+        return new UpdateArticleCommand(
+                articleId,
+                request.getTitle(),
+                request.getContent(),
+                request.getTags());
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/article/command/infra/JpaArticleRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/infra/JpaArticleRepository.java
@@ -14,5 +14,5 @@ import java.util.Optional;
 @Repository
 public interface JpaArticleRepository extends ArticleRepository, JpaRepository<Article, ArticleId> {
 
-    Optional<Article> findByArticleId(ArticleId articleId);
+    Optional<Article> findByArticleIdAndDeletedAtIsNull(ArticleId articleId);
 }

--- a/src/main/java/app/slicequeue/sq_board/article/command/infra/JpaArticleRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/infra/JpaArticleRepository.java
@@ -1,0 +1,17 @@
+package app.slicequeue.sq_board.article.command.infra;
+
+import app.slicequeue.sq_board.article.command.domain.Article;
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import app.slicequeue.sq_board.article.command.domain.ArticleRepository;
+import app.slicequeue.sq_board.board.command.domain.Board;
+import app.slicequeue.sq_board.board.command.domain.BoardId;
+import app.slicequeue.sq_board.board.command.domain.BoardRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface JpaArticleRepository extends ArticleRepository, JpaRepository<Article, ArticleId> {
+
+}

--- a/src/main/java/app/slicequeue/sq_board/article/command/infra/JpaArticleRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/infra/JpaArticleRepository.java
@@ -14,4 +14,5 @@ import java.util.Optional;
 @Repository
 public interface JpaArticleRepository extends ArticleRepository, JpaRepository<Article, ArticleId> {
 
+    Optional<Article> findByArticleId(ArticleId articleId);
 }

--- a/src/main/java/app/slicequeue/sq_board/article/command/presentation/ArticleCommandController.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/presentation/ArticleCommandController.java
@@ -2,14 +2,15 @@ package app.slicequeue.sq_board.article.command.presentation;
 
 import app.slicequeue.common.dto.CommonResponse;
 import app.slicequeue.sq_board.article.command.application.CreateArticleService;
+import app.slicequeue.sq_board.article.command.application.UpdateArticleService;
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
 import app.slicequeue.sq_board.article.command.domain.dto.CreateArticleCommand;
+import app.slicequeue.sq_board.article.command.domain.dto.UpdateArticleCommand;
 import app.slicequeue.sq_board.article.command.presentation.dto.CreateArticleRequest;
+import app.slicequeue.sq_board.article.command.presentation.dto.UpdateArticleRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1/articles")
@@ -17,11 +18,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class ArticleCommandController {
 
     private final CreateArticleService createArticleService;
+    private final UpdateArticleService updateArticleService;
 
     @PostMapping
     public CommonResponse<String> create(@RequestBody @Valid CreateArticleRequest request) {
         CreateArticleCommand command = CreateArticleCommand.from(request);
         return CommonResponse.success("created", createArticleService.createArticle(command).toString());
+    }
+
+    @PutMapping("/{articleId}")
+    public CommonResponse<String> update(@PathVariable("articleId") Long articleId,
+                                         @RequestBody @Valid UpdateArticleRequest updateArticleRequest) {
+        UpdateArticleCommand command = UpdateArticleCommand.from(ArticleId.from(articleId), updateArticleRequest);
+        return CommonResponse.success("updated", updateArticleService.updateArticle(command).toString());
     }
 
 }

--- a/src/main/java/app/slicequeue/sq_board/article/command/presentation/ArticleCommandController.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/presentation/ArticleCommandController.java
@@ -2,9 +2,11 @@ package app.slicequeue.sq_board.article.command.presentation;
 
 import app.slicequeue.common.dto.CommonResponse;
 import app.slicequeue.sq_board.article.command.application.CreateArticleService;
+import app.slicequeue.sq_board.article.command.application.DeleteArticleService;
 import app.slicequeue.sq_board.article.command.application.UpdateArticleService;
 import app.slicequeue.sq_board.article.command.domain.ArticleId;
 import app.slicequeue.sq_board.article.command.domain.dto.CreateArticleCommand;
+import app.slicequeue.sq_board.article.command.domain.dto.DeleteArticleCommand;
 import app.slicequeue.sq_board.article.command.domain.dto.UpdateArticleCommand;
 import app.slicequeue.sq_board.article.command.presentation.dto.CreateArticleRequest;
 import app.slicequeue.sq_board.article.command.presentation.dto.UpdateArticleRequest;
@@ -19,6 +21,7 @@ public class ArticleCommandController {
 
     private final CreateArticleService createArticleService;
     private final UpdateArticleService updateArticleService;
+    private final DeleteArticleService deleteArticleService;
 
     @PostMapping
     public CommonResponse<String> create(@RequestBody @Valid CreateArticleRequest request) {
@@ -31,6 +34,12 @@ public class ArticleCommandController {
                                          @RequestBody @Valid UpdateArticleRequest updateArticleRequest) {
         UpdateArticleCommand command = UpdateArticleCommand.from(ArticleId.from(articleId), updateArticleRequest);
         return CommonResponse.success("updated", updateArticleService.updateArticle(command).toString());
+    }
+
+    @DeleteMapping("/{articleId}")
+    public CommonResponse<String> delete(@PathVariable("articleId") Long articleId) {
+        DeleteArticleCommand command = DeleteArticleCommand.from(articleId);
+        return CommonResponse.success("deleted", deleteArticleService.deleteArticle(command).toString());
     }
 
 }

--- a/src/main/java/app/slicequeue/sq_board/article/command/presentation/ArticleCommandController.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/presentation/ArticleCommandController.java
@@ -1,0 +1,27 @@
+package app.slicequeue.sq_board.article.command.presentation;
+
+import app.slicequeue.common.dto.CommonResponse;
+import app.slicequeue.sq_board.article.command.application.CreateArticleService;
+import app.slicequeue.sq_board.article.command.domain.dto.CreateArticleCommand;
+import app.slicequeue.sq_board.article.command.presentation.dto.CreateArticleRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/articles")
+@RequiredArgsConstructor
+public class ArticleCommandController {
+
+    private final CreateArticleService createArticleService;
+
+    @PostMapping
+    public CommonResponse<String> create(@RequestBody @Valid CreateArticleRequest request) {
+        CreateArticleCommand command = CreateArticleCommand.from(request);
+        return CommonResponse.success("created", createArticleService.createArticle(command).toString());
+    }
+
+}

--- a/src/main/java/app/slicequeue/sq_board/article/command/presentation/dto/CreateArticleRequest.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/presentation/dto/CreateArticleRequest.java
@@ -1,0 +1,38 @@
+package app.slicequeue.sq_board.article.command.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CreateArticleRequest {
+
+    @NotNull(message = "boardId must not be null")
+    private final String boardId;
+    @NotBlank(message = "title must not be blank")
+    private final String title;
+    @NotBlank(message = "content must not be blank")
+    private final String content;
+    private final List<String> tags;
+    @NotNull(message = "writerId must not be null")
+    private final String writerId;
+    @NotBlank(message = "writerName must not be blank")
+    private final String writerName;
+
+    public CreateArticleRequest(
+            String boardId,
+            String title,
+            String content,
+            List<String> tags,
+            String writerId,
+            String writerName) {
+        this.boardId = boardId;
+        this.title = title;
+        this.content = content;
+        this.tags = tags;
+        this.writerId = writerId;
+        this.writerName = writerName;
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/article/command/presentation/dto/UpdateArticleRequest.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/presentation/dto/UpdateArticleRequest.java
@@ -1,0 +1,26 @@
+package app.slicequeue.sq_board.article.command.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UpdateArticleRequest {
+
+    @NotBlank(message = "title must not be blank")
+    private final String title;
+    @NotBlank(message = "content must not be blank")
+    private final String content;
+    private final List<String> tags;
+
+    public UpdateArticleRequest(
+            String title,
+            String content,
+            List<String> tags) {
+        this.title = title;
+        this.content = content;
+        this.tags = tags;
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/common/util/StringListConverter.java
+++ b/src/main/java/app/slicequeue/sq_board/common/util/StringListConverter.java
@@ -1,0 +1,33 @@
+package app.slicequeue.sq_board.common.util;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+
+        return String.join(DELIMITER, attribute);
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(dbData.split(DELIMITER))
+                .map(String::trim)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/db/ddl/init.sql
+++ b/src/main/resources/db/ddl/init.sql
@@ -13,3 +13,18 @@ CREATE TABLE board (
    PRIMARY KEY (board_id),
    KEY idx_project_id_board_id (project_id,board_id DESC)
 );
+
+CREATE TABLE article (
+   article_id bigint NOT NULL,
+   board_id bigint NOT NULL,
+   title varchar(512) COLLATE utf8mb4_general_ci NOT NULL,
+   writer_id bigint NOT NULL,
+   writer_name varchar(512) COLLATE utf8mb4_general_ci NOT NULL,
+   tags varchar(512) COLLATE utf8mb4_general_ci NOT NULL,
+   content TEXT COLLATE utf8mb4_general_ci NOT NULL,
+   deleted_at datetime NULL,
+   created_at datetime NOT NULL,
+   updated_at datetime NOT NULL,
+   PRIMARY KEY (article_id),
+   KEY idx_board_id_article_id (board_id, article_id DESC)
+);


### PR DESCRIPTION

### 변경 사항
1. **게시글 생성 API**  
   - 새로운 게시글을 생성할 수 있는 API 구현.
   - 요청 본문에 필요한 필드와 예외 처리 로직 추가.

2. **게시글 수정 API**  
   - 기존 게시글의 내용을 수정할 수 있는 API 구현.
   - 수정 권한 검증 및 예외 처리 포함.

3. **게시글 삭제 API**  
   - 게시글을 삭제할 수 있는 API 구현.
   - 삭제 권한 검증 및 관련 데이터 정리 로직 추가.

---

### 테스트
- 단위 테스트: 게시글 생성, 수정, 삭제 각각에 대한 테스트 케이스 작성.
- 통합 테스트: 전체 API 흐름에 대한 테스트 수행 및 검증.

---

### 참고 사항
- 추가적으로 논의가 필요한 사항이 있다면 코멘트를 남겨주세요.
- 관련된 이슈 번호: #6
