### PR TITLE
[API] 코멘트 등록 API, 코멘트 엔티티 선언

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 	testRuntimeOnly 'com.h2database:h2:2.2.224'
 
 	implementation 'app.slicequeue:sq-common-response-and-exception:0.0.2'
-	implementation 'app.slicequeue:sq-common-base-time-entity:0.0.1'
+	implementation 'app.slicequeue:sq-common-base-time-entity:0.0.3'
 	implementation 'app.slicequeue:sq-common-snowflake:0.0.1'
 }
 

--- a/src/main/java/app/slicequeue/sq_board/article/command/domain/Article.java
+++ b/src/main/java/app/slicequeue/sq_board/article/command/domain/Article.java
@@ -1,6 +1,6 @@
 package app.slicequeue.sq_board.article.command.domain;
 
-import app.slicequeue.common.base.time_entity.BaseTimeSoftDeleteEntity;
+import app.slicequeue.common.base.time_entity.BaseTimeSoftDeletedAtEntity;
 import app.slicequeue.sq_board.article.command.domain.dto.CreateArticleCommand;
 import app.slicequeue.sq_board.article.command.domain.dto.UpdateArticleCommand;
 import app.slicequeue.sq_board.board.command.domain.BoardId;
@@ -21,7 +21,7 @@ import java.util.List;
 @Entity
 @SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Article extends BaseTimeSoftDeleteEntity {
+public class Article extends BaseTimeSoftDeletedAtEntity {
 
     @EmbeddedId
     private ArticleId articleId;

--- a/src/main/java/app/slicequeue/sq_board/board/command/domain/Board.java
+++ b/src/main/java/app/slicequeue/sq_board/board/command/domain/Board.java
@@ -1,6 +1,6 @@
 package app.slicequeue.sq_board.board.command.domain;
 
-import app.slicequeue.common.base.time_entity.BaseTimeSoftDeleteEntity;
+import app.slicequeue.common.base.time_entity.BaseTimeSoftDeletedAtEntity;
 import app.slicequeue.sq_board.board.command.domain.dto.CreateBoardCommand;
 import app.slicequeue.sq_board.board.command.domain.dto.UpdateBoardCommand;
 import jakarta.persistence.EmbeddedId;
@@ -20,7 +20,7 @@ import org.springframework.util.Assert;
 @Entity
 @ToString
 @NoArgsConstructor
-public class Board extends BaseTimeSoftDeleteEntity {
+public class Board extends BaseTimeSoftDeletedAtEntity {
 
     static final int MIN_SIZE_NAME = 1;
     static final int MAX_SIZE_NAME = 100;

--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/CreateCommentService.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/CreateCommentService.java
@@ -1,0 +1,39 @@
+package app.slicequeue.sq_board.comment.command.application;
+
+import app.slicequeue.sq_board.comment.command.domain.Comment;
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+import app.slicequeue.sq_board.comment.command.domain.CommentPath;
+import app.slicequeue.sq_board.comment.command.domain.CommentRepository;
+import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CreateCommentService {
+
+    private final CommentRepository commentRepository;
+
+    public CommentId createComment(CreateCommentCommand command) {
+        Comment parent = findParent(command);
+        CommentPath parentCommentPath = parent == null ? CommentPath.create("") : parent.getPath();
+
+        Comment comment = Comment.create(command,
+                parentCommentPath.createChildCommentPath(
+                        commentRepository.findDescendantsTopPath(command.articleId(),
+                                parentCommentPath.getPath()).orElse(null))
+        );
+        return commentRepository.save(comment).getCommentId();
+    }
+
+    private Comment findParent(CreateCommentCommand command) {
+        CommentPath parentPath = command.parentPath();
+        if (parentPath == null) {
+            return null;
+        }
+        return commentRepository.findByPath(parentPath).orElseThrow();
+    }
+
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/Comment.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/Comment.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Table(name = "comment", indexes = {
         @Index(name = "idx_article_id_path", columnList = "article_id,path"),
@@ -16,6 +17,7 @@ import lombok.NoArgsConstructor;
 })
 @Entity
 @Getter
+@SQLRestriction("deleted IS FALSE")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseTimeSoftDeletedEntity {
 
@@ -36,14 +38,14 @@ public class Comment extends BaseTimeSoftDeletedEntity {
     @NotNull(message = "path must not be null")
     private CommentPath path;
 
-    public static Comment create(CreateCommentCommand command) {
+    public static Comment create(CreateCommentCommand command, CommentPath createdCommentPath) {
         Comment comment = new Comment();
-        comment.commentId = command.commentId();
+        comment.commentId = CommentId.generateId();
         comment.content = command.content();
         comment.articleId = command.articleId();
         comment.writerId = command.writerId();
         comment.writerNickname = command.writerNickname();
-        comment.path = command.path();
+        comment.path = createdCommentPath;
         return comment;
     }
 }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/Comment.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/Comment.java
@@ -1,0 +1,50 @@
+package app.slicequeue.sq_board.comment.command.domain;
+
+import app.slicequeue.common.base.time_entity.BaseTimeSoftDeletedEntity;
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "comment", indexes = {
+        @Index(name = "idx_article_id_path", columnList = "article_id,path"),
+        @Index(name = "idx_article_id_parent_comment_id_comment_id", columnList = "article_id,parent_comment_id,comment_id"),
+})
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseTimeSoftDeletedEntity {
+
+    @EmbeddedId
+    @AttributeOverride(name = "id", column = @Column(name = "comment_id"))
+    private CommentId commentId;
+    @Size(min = 1, max = 3000)
+    @NotNull(message = "content must not be null")
+    private String content;
+    @NotNull(message = "articleId must not be null")
+    private ArticleId articleId;
+    @AttributeOverride(name = "id", column = @Column(name = "parent_comment_id"))
+    private CommentId parentCommentId;
+    @NotNull(message = "writerId must not be null")
+    private Long writerId;
+    @NotNull(message = "writerName must not be null")
+    private String writerNickname;
+    @NotNull(message = "path must not be null")
+    private CommentPath path;
+
+    public static Comment create(CreateCommentCommand command) {
+        Comment comment = new Comment();
+        comment.commentId = command.commentId();
+        comment.content = command.content();
+        comment.articleId = command.articleId();
+        comment.writerId = command.writerId();
+        comment.writerNickname = command.writerNickname();
+        comment.path = command.path();
+        return comment;
+    }
+}
+

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentId.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentId.java
@@ -1,0 +1,29 @@
+package app.slicequeue.sq_board.comment.command.domain;
+
+import app.slicequeue.common.snowflake.Snowflake;
+import app.slicequeue.sq_board.common.base.AbstractSnowflakeId;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class CommentId extends AbstractSnowflakeId<CommentId> {
+
+    static Snowflake snowflake = new Snowflake();
+
+    public CommentId(long id) {
+        super(id);
+    }
+
+    public static CommentId generateId() {
+        return new CommentId(snowflake.nextId());
+    }
+
+    @Override
+    protected Snowflake getSnowflake() {
+        return snowflake;
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentPath.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentPath.java
@@ -1,0 +1,95 @@
+package app.slicequeue.sq_board.comment.command.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentPath {
+
+    private String path;
+
+    private static final String CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"; // 한글자에 올 62 진수 만들 알파벳들 숫자 조합 0 -> z
+
+    private static final int DEPTH_CHUNK_SIZE = 5;   // 경로 정보 1댑스당 5자리로 표시
+    private static final int MAX_DEPTH = 5;          // 최대 경로는 5 뎁스 까지
+
+    // "00000" ~ "zzzzz"
+    private static final String MIN_CHUNK = String.valueOf(CHARSET.charAt(0)).repeat(DEPTH_CHUNK_SIZE); // 00000
+    private static final String MAX_CHUNK =
+            String.valueOf(CHARSET.charAt(CHARSET.length() - 1)).repeat(DEPTH_CHUNK_SIZE); // zzzzz
+
+    public static CommentPath create(String path) {
+        if (isDepthOverflowed(path)) {
+            throw new IllegalStateException("depth overflowed");
+        }
+        CommentPath commentPath = new CommentPath();
+        commentPath.path = path;
+        return commentPath;
+    }
+
+    private static boolean isDepthOverflowed(String path) {
+        return calDepth(path) > MAX_DEPTH;
+    }
+
+    private static int calDepth(String path) {
+        return path.length() / DEPTH_CHUNK_SIZE;
+    }
+
+    public int getDepth() {
+        return calDepth(path);
+    }
+
+    public boolean isRoot() {
+        return calDepth(path) == 1;
+    }
+
+    public String getParentPath() {
+        return path.substring(0, path.length() - DEPTH_CHUNK_SIZE);
+    }
+
+    public CommentPath createChildCommentPath(String descendantsTopPath) {
+        if (descendantsTopPath == null) {
+            return CommentPath.create(path + MIN_CHUNK);
+        }
+        String childrenTopPath = findChildrenTopPath(descendantsTopPath);
+        return CommentPath.create(increase(childrenTopPath));
+    }
+
+    private String findChildrenTopPath(String descendantsTopPath) {
+        return descendantsTopPath.substring(0, (getDepth() + 1) * DEPTH_CHUNK_SIZE);
+    }
+
+    private String increase(String path) {
+        // 00000 00000
+        String lastChunk = path.substring(path.length() - DEPTH_CHUNK_SIZE);
+        if (isChunkOverflowed(lastChunk)) {
+            throw new IllegalStateException("chunk overflowed");
+        }
+        int charsetLength = CHARSET.length();
+        int value = 0;
+        for (char ch : lastChunk.toCharArray()) {
+            value = value * charsetLength + CHARSET.indexOf(ch); // 문자열 62진수를 정수값으로 변환
+            // 마지막 청크 문자를 정수 값으로 누적 환산
+        }
+
+        value = value + 1; // 1 증가 시키기
+
+        String result = "";
+        for (int i=0; i < DEPTH_CHUNK_SIZE; i++) {
+            result = CHARSET.charAt(value % charsetLength) + result; // 다시 정수를 62 진수로 전환 나머지로 문자열 변환
+            value /= charsetLength; // 정수에서 62진수 한자리 진행한 것 반영
+        }
+
+        return path.substring(0, path.length() - DEPTH_CHUNK_SIZE) + result; // 끝에 다시 붙이기
+    }
+
+    private boolean isChunkOverflowed(String lastChunk) {
+        return MAX_CHUNK.equals(lastChunk);
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentPath.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentPath.java
@@ -53,6 +53,11 @@ public class CommentPath {
         return path.substring(0, path.length() - DEPTH_CHUNK_SIZE);
     }
 
+    public CommentPath createChildCommentPath(CommentPath descendantsTopPath) {
+        return createChildCommentPath(
+                descendantsTopPath != null ? descendantsTopPath.getPath() : null);
+    }
+
     public CommentPath createChildCommentPath(String descendantsTopPath) {
         if (descendantsTopPath == null) {
             return CommentPath.create(path + MIN_CHUNK);

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentPath.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentPath.java
@@ -25,11 +25,20 @@ public class CommentPath {
             String.valueOf(CHARSET.charAt(CHARSET.length() - 1)).repeat(DEPTH_CHUNK_SIZE); // zzzzz
 
     public static CommentPath create(String path) {
+        if (path == null) {
+            return CommentPath.empty();
+        }
         if (isDepthOverflowed(path)) {
             throw new IllegalStateException("depth overflowed");
         }
         CommentPath commentPath = new CommentPath();
         commentPath.path = path;
+        return commentPath;
+    }
+
+    public static CommentPath empty() {
+        CommentPath commentPath = new CommentPath();
+        commentPath.path = null;
         return commentPath;
     }
 
@@ -58,7 +67,7 @@ public class CommentPath {
                 descendantsTopPath != null ? descendantsTopPath.getPath() : null);
     }
 
-    public CommentPath createChildCommentPath(String descendantsTopPath) {
+    private CommentPath createChildCommentPath(String descendantsTopPath) {
         if (descendantsTopPath == null) {
             return CommentPath.create(path + MIN_CHUNK);
         }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentRepository.java
@@ -1,0 +1,18 @@
+package app.slicequeue.sq_board.comment.command.domain;
+
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CommentRepository {
+
+    Comment save(Comment comment);
+
+    Optional<Comment> findByPath(CommentPath path);
+
+    Optional<CommentPath> findDescendantsTopPath(@Param("articleId") ArticleId articleId,
+                                               @Param("pathPrefix") String pathPrefix);
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/dto/CreateCommentCommand.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/dto/CreateCommentCommand.java
@@ -1,12 +1,22 @@
 package app.slicequeue.sq_board.comment.command.domain.dto;
 
 import app.slicequeue.sq_board.article.command.domain.ArticleId;
-import app.slicequeue.sq_board.comment.command.domain.CommentId;
 import app.slicequeue.sq_board.comment.command.domain.CommentPath;
+import app.slicequeue.sq_board.comment.command.presentation.dto.CreateCommentRequest;
 
-public record CreateCommentCommand(CommentId commentId,
-                                   String content,
+public record CreateCommentCommand(String content,
                                    ArticleId articleId,
                                    Long writerId,
                                    String writerNickname,
-                                   CommentPath path) { }
+                                   CommentPath parentPath) {
+    public static CreateCommentCommand from(CreateCommentRequest request) {
+        return new CreateCommentCommand(
+                request.getContent(),
+                ArticleId.from(request.getArticleId()),
+                request.getWriterId(),
+                request.getWriterNickname(),
+                request.getParentPath() != null
+                    ? CommentPath.create(request.getParentPath())
+                    : null);
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/dto/CreateCommentCommand.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/dto/CreateCommentCommand.java
@@ -1,0 +1,12 @@
+package app.slicequeue.sq_board.comment.command.domain.dto;
+
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+import app.slicequeue.sq_board.comment.command.domain.CommentPath;
+
+public record CreateCommentCommand(CommentId commentId,
+                                   String content,
+                                   ArticleId articleId,
+                                   Long writerId,
+                                   String writerNickname,
+                                   CommentPath path) { }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/infra/JpaCommentRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/infra/JpaCommentRepository.java
@@ -1,0 +1,29 @@
+package app.slicequeue.sq_board.comment.command.infra;
+
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import app.slicequeue.sq_board.comment.command.domain.Comment;
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+import app.slicequeue.sq_board.comment.command.domain.CommentPath;
+import app.slicequeue.sq_board.comment.command.domain.CommentRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface JpaCommentRepository extends JpaRepository<Comment, CommentId>, CommentRepository {
+
+    Comment save(Comment comment);
+
+    Optional<Comment> findByPath(CommentPath path);
+
+    @Query("""
+            select c.path from Comment c
+            where c.articleId = :articleId
+            and c.path.path > :pathPrefix and c.path.path like :pathPrefix%
+            order by path.path desc limit 1
+            """)
+    Optional<CommentPath> findDescendantsTopPath(
+            @Param("articleId") ArticleId articleId,
+            @Param("pathPrefix") String pathPrefix);
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/presentation/CommentCommandController.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/presentation/CommentCommandController.java
@@ -1,0 +1,27 @@
+package app.slicequeue.sq_board.comment.command.presentation;
+
+import app.slicequeue.common.dto.CommonResponse;
+import app.slicequeue.sq_board.comment.command.application.CreateCommentService;
+import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
+import app.slicequeue.sq_board.comment.command.presentation.dto.CreateCommentRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/comments")
+@RequiredArgsConstructor
+public class CommentCommandController {
+
+    private final CreateCommentService createCommentService;
+
+    @PostMapping
+    public CommonResponse<String> create(@RequestBody @Valid CreateCommentRequest request) {
+        CreateCommentCommand command = CreateCommentCommand.from(request);
+        return CommonResponse.success("created", createCommentService.createComment(command).toString());
+    }
+
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/presentation/dto/CreateCommentRequest.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/presentation/dto/CreateCommentRequest.java
@@ -1,0 +1,19 @@
+package app.slicequeue.sq_board.comment.command.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class CreateCommentRequest {
+    @Size(min = 1, max = 3000)
+    @NotNull(message = "content must not be null")
+    String content;
+    @NotNull(message = "articleId must not be null")
+    Long articleId;
+    @NotNull(message = "writerId must not be null")
+    Long writerId;
+    @NotNull(message = "writerNickname must not be null")
+    String writerNickname;
+    String parentPath;
+}

--- a/src/main/java/app/slicequeue/sq_board/common/base/AbstractSnowflakeId.java
+++ b/src/main/java/app/slicequeue/sq_board/common/base/AbstractSnowflakeId.java
@@ -1,0 +1,63 @@
+package app.slicequeue.sq_board.common.base;
+
+import app.slicequeue.common.snowflake.Snowflake;
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+
+@MappedSuperclass
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class AbstractSnowflakeId<T extends AbstractSnowflakeId<T>> implements Serializable {
+
+    @NotNull
+    @Column(name = "id")
+    protected Long id;
+
+    protected AbstractSnowflakeId(Long id) {
+        this.id = id;
+    }
+
+    protected abstract Snowflake getSnowflake();
+
+    public T generate() {
+        try {
+            T instance = (T) this.getClass().getDeclaredConstructor().newInstance();
+            instance.id = getSnowflake().nextId();
+            return instance;
+        } catch (Exception e) {
+            throw new RuntimeException("ID 생성 실패", e);
+        }
+    }
+
+
+
+    public static <T extends AbstractSnowflakeId<T>> T from(Long id, Class<T> clazz) {
+        Assert.notNull(id, "id must not be null");
+        if (id <= 0) throw new IllegalArgumentException("id must be positive");
+        try {
+            return clazz.getConstructor(Long.class).newInstance(id);
+        } catch (Exception e) {
+            throw new RuntimeException("ID from(Long) 생성 실패", e);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(id);
+    }
+}
+

--- a/src/main/resources/db/ddl/init.sql
+++ b/src/main/resources/db/ddl/init.sql
@@ -28,3 +28,19 @@ CREATE TABLE article (
    PRIMARY KEY (article_id),
    KEY idx_board_id_article_id (board_id, article_id DESC)
 );
+
+create table comment(
+	comment_id bigint not null primary key,
+    content varchar(3000) not null,
+    article_id bigint not null,
+    parent_comment_id bigint NULL,
+    writer_id bigint not null,
+    writer_nickname varchar(100) not null,
+    path varchar(25) character set utf8mb4 collate utf8mb4_bin not null,
+    deleted boolean not null default false,
+    created_at datetime not null,
+    updated_at datetime NOT NULL
+);
+
+create unique index idx_article_id_path on comment(article_id asc, path asc);
+create unique index idx_article_id_parent_comment_id_comment_id on comment(article_id, parent_comment_id, comment_id);

--- a/src/test/java/app/slicequeue/sq_board/comment/command/domain/CommentPathTest.java
+++ b/src/test/java/app/slicequeue/sq_board/comment/command/domain/CommentPathTest.java
@@ -1,0 +1,53 @@
+package app.slicequeue.sq_board.comment.command.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CommentPathTest {
+
+    @Test
+    void createChildCommentTest() {
+        // 00000 <- 생성
+        createChildCommentTest(CommentPath.create(""), null, "00000");
+
+        // 00000(현위치)
+        //      00000 <- 생성
+        createChildCommentTest(CommentPath.create("00000"), null, "0000000000");
+
+        // (현위치)
+        // 00000
+        // 00001 <- 생성
+        createChildCommentTest(CommentPath.create(""), "00000", "00001");
+
+        // 0000z(현위치)
+        //      abcdz
+        //           zzzzz
+        //                zzzzz
+        //       abce0 <- 생성
+        createChildCommentTest(CommentPath.create("0000z"), "0000zabcdzzzzzzzzzzz", "0000zabce0");
+    }
+
+    void createChildCommentTest(CommentPath commentPath, String descendantsTopPath, String expectedChildPath) {
+        CommentPath childCommentPath = commentPath.createChildCommentPath(CommentPath.create(descendantsTopPath));
+        assertThat(childCommentPath.getPath()).isEqualTo(expectedChildPath);
+    }
+
+    @Test
+    void createChildCommentPathIfMaxDepthTest() {
+        assertThatThrownBy(() ->
+                CommentPath.create("zzzzz".repeat(5)).createChildCommentPath(null))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void createChildCommentPathIfChunkOverflowTest() {
+        // given
+        CommentPath commentPath = CommentPath.create("");
+
+        // when & then
+        assertThatThrownBy(() -> commentPath.createChildCommentPath(CommentPath.create("zzzzz")))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/app/slicequeue/sq_board/comment/command/domain/CommentTest.java
+++ b/src/test/java/app/slicequeue/sq_board/comment/command/domain/CommentTest.java
@@ -1,0 +1,37 @@
+package app.slicequeue.sq_board.comment.command.domain;
+
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class CommentTest {
+
+    @Autowired
+    TestEntityManager entityManager;
+
+    @Test
+    void 코멘트엔티티_삽입한다() {
+        // given
+        Comment comment = Comment.create(new CreateCommentCommand(
+                CommentId.generateId(),
+                "내용",
+                ArticleId.generateId(),
+                123L,
+                "작성자 닉네임",
+                CommentPath.create("")
+        ));
+
+        // when
+        Comment result = entityManager.persistAndFlush(comment);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+
+}

--- a/src/test/java/app/slicequeue/sq_board/comment/command/domain/CommentTest.java
+++ b/src/test/java/app/slicequeue/sq_board/comment/command/domain/CommentTest.java
@@ -19,7 +19,6 @@ class CommentTest {
     void 코멘트엔티티_삽입한다() {
         // given
         Comment comment = Comment.create(new CreateCommentCommand(
-                CommentId.generateId(),
                 "내용",
                 ArticleId.generateId(),
                 123L,

--- a/src/test/java/app/slicequeue/sq_board/comment/command/domain/CommentTest.java
+++ b/src/test/java/app/slicequeue/sq_board/comment/command/domain/CommentTest.java
@@ -24,7 +24,7 @@ class CommentTest {
                 123L,
                 "작성자 닉네임",
                 CommentPath.create("")
-        ));
+        ), CommentPath.create(""));
 
         // when
         Comment result = entityManager.persistAndFlush(comment);


### PR DESCRIPTION
### 변경 내용
1. **기능 추가**
   - 코멘트 등록 API를 위한 `CreateCommentService` 추가:
     - 코멘트 생성 로직 구현.
     - 부모 코멘트 경로를 기반으로 하위 코멘트 경로를 생성.
   - 코멘트 도메인 엔티티(`Comment`) 선언:
     - 코멘트 데이터 모델 정의 (내용, 작성자 정보, 경로 등).
   - 코멘트 관련 식별자(`CommentId`) 추가:
     - Snowflake 기반 식별자 생성.
   - 코멘트 경로 관리 클래스(`CommentPath`) 추가:
     - 경로 기반 계층 구조 관리 로직 구현.
   - 코멘트 저장소 인터페이스 및 구현체 추가:
     - `CommentRepository` 및 `JpaCommentRepository` 생성.
   - 코멘트 생성 요청/명령용 DTO 추가:
     - `CreateCommentCommand` 및 관련 요청 객체 정의.

2. **기존 코드 수정**
   - `Article` 및 `Board` 엔티티에서 상속 클래스 변경:
     - `BaseTimeSoftDeleteEntity` → `BaseTimeSoftDeletedAtEntity`.

3. **Dependency 업데이트**
   - `build.gradle`에서 `app.slicequeue:sq-common-base-time-entity` 버전 `0.0.1` → `0.0.3`로 업데이트.

---

### 변경 이유
- 코멘트 등록 API를 통해 게시판의 기본 기능을 확장하기 위함.
- 경로 기반의 계층 구조를 통해 코멘트의 부모-자식 관계를 효율적으로 관리.
- 공통 엔티티(`BaseTimeSoftDeletedAtEntity`)로의 전환을 통해 일관된 삭제 처리 구현.

---

### 테스트
- 코멘트 생성 로직 및 경로 구조에 대한 단위 테스트 추가 필요.
- API 통합 테스트를 통해 동작 확인 예정.
