### PR TITLE
[COMMENT] 댓글 수정 API

### DIFF
--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/CreateCommentService.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/CreateCommentService.java
@@ -35,5 +35,4 @@ public class CreateCommentService {
         }
         return commentRepository.findByPath(parentPath).orElseThrow();
     }
-
 }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/UpdateCommentService.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/UpdateCommentService.java
@@ -1,0 +1,27 @@
+package app.slicequeue.sq_board.comment.command.application;
+
+import app.slicequeue.common.exception.NotFoundException;
+import app.slicequeue.sq_board.comment.command.domain.Comment;
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+import app.slicequeue.sq_board.comment.command.domain.CommentPath;
+import app.slicequeue.sq_board.comment.command.domain.CommentRepository;
+import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
+import app.slicequeue.sq_board.comment.command.domain.dto.UpdateCommentCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UpdateCommentService {
+
+    private final CommentRepository commentRepository;
+
+    public CommentId updateComment(UpdateCommentCommand command) {
+        Comment comment = commentRepository.findByCommentId(command.commentId())
+                .orElseThrow(() -> new NotFoundException("댓글을 찾을 수가 없습니다."));
+        comment.update(command);
+        return commentRepository.save(comment).getCommentId();
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/Comment.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/Comment.java
@@ -3,6 +3,7 @@ package app.slicequeue.sq_board.comment.command.domain;
 import app.slicequeue.common.base.time_entity.BaseTimeSoftDeletedEntity;
 import app.slicequeue.sq_board.article.command.domain.ArticleId;
 import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
+import app.slicequeue.sq_board.comment.command.domain.dto.UpdateCommentCommand;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -47,6 +48,12 @@ public class Comment extends BaseTimeSoftDeletedEntity {
         comment.writerNickname = command.writerNickname();
         comment.path = createdCommentPath;
         return comment;
+    }
+
+    public void update(UpdateCommentCommand command) {
+        this.content = command.content();
+        this.writerNickname = command.writerNickname();
+        nowUpdateAt();
     }
 }
 

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentId.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentId.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -14,12 +15,16 @@ public class CommentId extends AbstractSnowflakeId<CommentId> {
 
     static Snowflake snowflake = new Snowflake();
 
-    public CommentId(long id) {
+    public CommentId(Long id) {
         super(id);
     }
 
     public static CommentId generateId() {
         return new CommentId(snowflake.nextId());
+    }
+
+    public static CommentId from(Long idValue) {
+        return from(idValue, CommentId.class);
     }
 
     @Override

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentRepository.java
@@ -11,6 +11,8 @@ public interface CommentRepository {
 
     Comment save(Comment comment);
 
+    Optional<Comment> findByCommentId(CommentId commentId);
+
     Optional<Comment> findByPath(CommentPath path);
 
     Optional<CommentPath> findDescendantsTopPath(@Param("articleId") ArticleId articleId,

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/dto/UpdateCommentCommand.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/dto/UpdateCommentCommand.java
@@ -1,0 +1,19 @@
+package app.slicequeue.sq_board.comment.command.domain.dto;
+
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+import app.slicequeue.sq_board.comment.command.domain.CommentPath;
+import app.slicequeue.sq_board.comment.command.presentation.dto.CreateCommentRequest;
+import app.slicequeue.sq_board.comment.command.presentation.dto.UpdateCommentRequest;
+
+public record UpdateCommentCommand(
+        CommentId commentId,
+        String content,
+        String writerNickname) {
+    public static UpdateCommentCommand of(CommentId commentId, UpdateCommentRequest request) {
+        return new UpdateCommentCommand(
+                commentId,
+                request.getContent(),
+                request.getWriterNickname());
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/infra/JpaCommentRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/infra/JpaCommentRepository.java
@@ -15,6 +15,8 @@ public interface JpaCommentRepository extends JpaRepository<Comment, CommentId>,
 
     Comment save(Comment comment);
 
+    Optional<Comment> findByCommentId(CommentId commentId);
+
     Optional<Comment> findByPath(CommentPath path);
 
     @Query("""

--- a/src/main/java/app/slicequeue/sq_board/comment/command/presentation/CommentCommandController.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/presentation/CommentCommandController.java
@@ -2,14 +2,15 @@ package app.slicequeue.sq_board.comment.command.presentation;
 
 import app.slicequeue.common.dto.CommonResponse;
 import app.slicequeue.sq_board.comment.command.application.CreateCommentService;
+import app.slicequeue.sq_board.comment.command.application.UpdateCommentService;
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
 import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
+import app.slicequeue.sq_board.comment.command.domain.dto.UpdateCommentCommand;
 import app.slicequeue.sq_board.comment.command.presentation.dto.CreateCommentRequest;
+import app.slicequeue.sq_board.comment.command.presentation.dto.UpdateCommentRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1/comments")
@@ -17,11 +18,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentCommandController {
 
     private final CreateCommentService createCommentService;
+    private final UpdateCommentService updateCommentService;
 
     @PostMapping
     public CommonResponse<String> create(@RequestBody @Valid CreateCommentRequest request) {
         CreateCommentCommand command = CreateCommentCommand.from(request);
         return CommonResponse.success("created", createCommentService.createComment(command).toString());
+    }
+
+    @PutMapping("/{commentId}")
+    public CommonResponse<String> update(@PathVariable("commentId") Long commentId,
+                                         @RequestBody @Valid UpdateCommentRequest request) {
+        UpdateCommentCommand command = UpdateCommentCommand.of(CommentId.from(commentId), request);
+        return CommonResponse.success("updated", updateCommentService.updateComment(command).toString());
     }
 
 }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/presentation/dto/UpdateCommentRequest.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/presentation/dto/UpdateCommentRequest.java
@@ -1,0 +1,14 @@
+package app.slicequeue.sq_board.comment.command.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdateCommentRequest {
+    @Size(min = 1, max = 3000)
+    @NotNull(message = "content must not be null")
+    String content;
+    @NotNull(message = "writerNickname must not be null")
+    String writerNickname;
+}

--- a/src/main/java/app/slicequeue/sq_board/common/base/AbstractSnowflakeId.java
+++ b/src/main/java/app/slicequeue/sq_board/common/base/AbstractSnowflakeId.java
@@ -40,13 +40,13 @@ public abstract class AbstractSnowflakeId<T extends AbstractSnowflakeId<T>> impl
 
 
 
-    public static <T extends AbstractSnowflakeId<T>> T from(Long id, Class<T> clazz) {
+    protected static <T extends AbstractSnowflakeId<T>> T from(Long id, Class<T> clazz) {
         Assert.notNull(id, "id must not be null");
         if (id <= 0) throw new IllegalArgumentException("id must be positive");
         try {
             return clazz.getConstructor(Long.class).newInstance(id);
         } catch (Exception e) {
-            throw new RuntimeException("ID from(Long) 생성 실패", e);
+            throw new RuntimeException("id from(Long) generate fail", e);
         }
     }
 


### PR DESCRIPTION
## ✨ 주요 변경 사항
1. **댓글 수정 기능 추가**:
   - `UpdateCommentService` 클래스가 새로 추가되어, 댓글을 수정하는 비즈니스 로직을 포함합니다.
   - 댓글 수정 요청을 처리할 DTO 클래스(`UpdateCommentCommand` 및 `UpdateCommentRequest`)가 추가되었습니다.
   - `Comment` 클래스에 `update` 메서드가 추가되어 댓글 내용 및 작성자 이름을 업데이트하도록 구현되었습니다.

2. **API 엔드포인트 추가**:
   - `CommentCommandController`에 `@PutMapping("/{commentId}")` 경로가 추가되어 댓글 ID를 기반으로 수정 요청을 처리합니다.

3. **Repository 변경**:
   - `CommentRepository` 및 `JpaCommentRepository`에 `findByCommentId` 메서드가 추가되었습니다.

4. **기타 변경**:
   - `AbstractSnowflakeId` 및 관련 클래스에 ID 생성 및 검증 로직이 수정되었습니다.

## 🚀 적용 방법
1. 클라이언트에서 페이지 번호와 데이터 수를 포함한 요청을 전송합니다.
2. 해당 API 엔드포인트를 호출하여 필요한 데이터만 페이지 단위로 받아옵니다.
3. 클라이언트에서 받은 데이터를 화면에 렌더링하여 페이징 UI를 구성합니다.

## ✅ 체크리스트
- [x] API 엔드포인트가 정상적으로 호출되는지 확인
- [ ] 페이징 로직이 정확히 작동하는지 테스트
- [ ] 다양한 페이지 요청 시 데이터가 올바르게 반환되는지 검증
- [ ] 관련 코드가 코드 리뷰 기준에 부합하는지 확인
