### PR TITLE
[COMMENT] 댓글 삭제 API

### DIFF
--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/DeleteCommentService.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/DeleteCommentService.java
@@ -1,0 +1,26 @@
+package app.slicequeue.sq_board.comment.command.application;
+
+import app.slicequeue.common.exception.NotFoundException;
+import app.slicequeue.sq_board.comment.command.domain.Comment;
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+import app.slicequeue.sq_board.comment.command.domain.CommentRepository;
+import app.slicequeue.sq_board.comment.command.domain.dto.DeleteCommentCommand;
+import app.slicequeue.sq_board.comment.command.domain.dto.UpdateCommentCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeleteCommentService {
+
+    private final CommentRepository commentRepository;
+
+    public CommentId deleteComment(DeleteCommentCommand command) {
+        Comment comment = commentRepository.findByCommentId(command.commentId())
+                .orElseThrow(() -> new NotFoundException("댓글을 찾을 수가 없습니다."));
+        comment.delete();
+        return commentRepository.save(comment).getCommentId();
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/Comment.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/Comment.java
@@ -55,5 +55,9 @@ public class Comment extends BaseTimeSoftDeletedEntity {
         this.writerNickname = command.writerNickname();
         nowUpdateAt();
     }
+
+    public void delete() {
+        super.delete();
+    }
 }
 

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentId.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentId.java
@@ -4,6 +4,7 @@ import app.slicequeue.common.snowflake.Snowflake;
 import app.slicequeue.sq_board.common.base.AbstractSnowflakeId;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
@@ -20,7 +21,7 @@ public class CommentId extends AbstractSnowflakeId<CommentId> {
     }
 
     public static CommentId generateId() {
-        return new CommentId(snowflake.nextId());
+        return new CommentId().generate();
     }
 
     public static CommentId from(Long idValue) {

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/dto/DeleteCommentCommand.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/dto/DeleteCommentCommand.java
@@ -1,0 +1,10 @@
+package app.slicequeue.sq_board.comment.command.domain.dto;
+
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+import app.slicequeue.sq_board.comment.command.presentation.dto.UpdateCommentRequest;
+
+public record DeleteCommentCommand(CommentId commentId) {
+    public static DeleteCommentCommand from(CommentId commentId) {
+        return new DeleteCommentCommand(commentId);
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/presentation/CommentCommandController.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/presentation/CommentCommandController.java
@@ -2,9 +2,11 @@ package app.slicequeue.sq_board.comment.command.presentation;
 
 import app.slicequeue.common.dto.CommonResponse;
 import app.slicequeue.sq_board.comment.command.application.CreateCommentService;
+import app.slicequeue.sq_board.comment.command.application.DeleteCommentService;
 import app.slicequeue.sq_board.comment.command.application.UpdateCommentService;
 import app.slicequeue.sq_board.comment.command.domain.CommentId;
 import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
+import app.slicequeue.sq_board.comment.command.domain.dto.DeleteCommentCommand;
 import app.slicequeue.sq_board.comment.command.domain.dto.UpdateCommentCommand;
 import app.slicequeue.sq_board.comment.command.presentation.dto.CreateCommentRequest;
 import app.slicequeue.sq_board.comment.command.presentation.dto.UpdateCommentRequest;
@@ -19,6 +21,7 @@ public class CommentCommandController {
 
     private final CreateCommentService createCommentService;
     private final UpdateCommentService updateCommentService;
+    private final DeleteCommentService deleteCommentService;
 
     @PostMapping
     public CommonResponse<String> create(@RequestBody @Valid CreateCommentRequest request) {
@@ -31,6 +34,12 @@ public class CommentCommandController {
                                          @RequestBody @Valid UpdateCommentRequest request) {
         UpdateCommentCommand command = UpdateCommentCommand.of(CommentId.from(commentId), request);
         return CommonResponse.success("updated", updateCommentService.updateComment(command).toString());
+    }
+
+    @DeleteMapping("/{commentId}")
+    public CommonResponse<String> delete(@PathVariable("commentId") Long commentId) {
+        DeleteCommentCommand command = DeleteCommentCommand.from(CommentId.from(commentId));
+        return CommonResponse.success("updated", deleteCommentService.deleteComment(command).toString());
     }
 
 }

--- a/src/main/java/app/slicequeue/sq_board/common/base/AbstractSnowflakeId.java
+++ b/src/main/java/app/slicequeue/sq_board/common/base/AbstractSnowflakeId.java
@@ -28,17 +28,18 @@ public abstract class AbstractSnowflakeId<T extends AbstractSnowflakeId<T>> impl
 
     protected abstract Snowflake getSnowflake();
 
+    @SuppressWarnings("unchecked") // 타입 안정성은 우리가 보장하고 있어서 문제 없음
     public T generate() {
         try {
-            T instance = (T) this.getClass().getDeclaredConstructor().newInstance();
+            var constructor = this.getClass().getDeclaredConstructor();
+            constructor.setAccessible(true); // 여기 추가! (Java 8)
+            T instance = (T) constructor.newInstance();
             instance.id = getSnowflake().nextId();
             return instance;
         } catch (Exception e) {
             throw new RuntimeException("ID 생성 실패", e);
         }
     }
-
-
 
     protected static <T extends AbstractSnowflakeId<T>> T from(Long id, Class<T> clazz) {
         Assert.notNull(id, "id must not be null");


### PR DESCRIPTION
## ✨ 주요 변경 사항
1. **댓글 삭제 기능 추가**:
   - `DeleteCommentService` 클래스가 추가되어 댓글 삭제 로직을 처리합니다.
   - 댓글 삭제를 위한 DTO 클래스(`DeleteCommentCommand`)가 추가되었습니다.
   - `Comment` 클래스에 `delete` 메서드가 추가되어 댓글 삭제 동작을 구현했습니다.

2. **API 엔드포인트 추가**:
   - `CommentCommandController`에 `@DeleteMapping("/{commentId}")` 경로가 추가되어 댓글 ID를 기반으로 삭제 요청을 처리합니다.

3. **기타 변경 사항**:
   - `AbstractSnowflakeId` 클래스에서 ID 생성 로직이 개선되었습니다.
   - `CommentId` 클래스의 ID 생성 메서드가 수정되었습니다.

## 🚀 적용 방법
1. 클라이언트에서 페이지 번호와 데이터 수를 포함한 요청을 전송합니다.
2. 해당 API 엔드포인트를 호출하여 필요한 데이터만 페이지 단위로 받아옵니다.
3. 클라이언트에서 받은 데이터를 화면에 렌더링하여 페이징 UI를 구성합니다.

## ✅ 체크리스트
- [x] API 엔드포인트가 정상적으로 호출되는지 확인
- [ ] 페이징 로직이 정확히 작동하는지 테스트
- [ ] 다양한 페이지 요청 시 데이터가 올바르게 반환되는지 검증
- [ ] 관련 코드가 코드 리뷰 기준에 부합하는지 확인
