### PR TITLE
[COMMENT] 댓글 상세 조회 API

### DIFF
--- a/src/main/java/app/slicequeue/sq_board/board/query/infra/JpaBoardQueryRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/board/query/infra/JpaBoardQueryRepository.java
@@ -10,11 +10,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
+@Transactional(readOnly = true)
 public interface JpaBoardQueryRepository extends JpaRepository<Board, BoardId> {
 
 

--- a/src/main/java/app/slicequeue/sq_board/comment/query/application/dto/ReadCommentDetailQuery.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/query/application/dto/ReadCommentDetailQuery.java
@@ -1,0 +1,9 @@
+package app.slicequeue.sq_board.comment.query.application.dto;
+
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+
+public record ReadCommentDetailQuery(CommentId commentId) {
+    public static ReadCommentDetailQuery from(Long id) {
+        return new ReadCommentDetailQuery(CommentId.from(id));
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/query/application/service/ReadCommentService.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/query/application/service/ReadCommentService.java
@@ -1,0 +1,24 @@
+package app.slicequeue.sq_board.comment.query.application.service;
+
+import app.slicequeue.common.exception.NotFoundException;
+import app.slicequeue.sq_board.comment.query.application.dto.ReadCommentDetailQuery;
+import app.slicequeue.sq_board.comment.query.infra.JpaCommentQueryRepository;
+import app.slicequeue.sq_board.comment.query.presentation.dto.CommentDetail;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ReadCommentService {
+
+    private final JpaCommentQueryRepository commentQueryRepository;
+
+
+    public CommentDetail read(ReadCommentDetailQuery query) {
+        return commentQueryRepository.findById(query.commentId())
+                .map(CommentDetail::from)
+                .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/query/infra/JpaCommentQueryRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/query/infra/JpaCommentQueryRepository.java
@@ -1,0 +1,14 @@
+package app.slicequeue.sq_board.comment.query.infra;
+
+import app.slicequeue.sq_board.comment.command.domain.Comment;
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(readOnly = true)
+public interface JpaCommentQueryRepository extends JpaRepository<Comment, CommentId> {
+
+
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/query/presentation/CommentQueryController.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/query/presentation/CommentQueryController.java
@@ -1,0 +1,26 @@
+package app.slicequeue.sq_board.comment.query.presentation;
+
+import app.slicequeue.common.dto.CommonResponse;
+import app.slicequeue.sq_board.comment.query.application.dto.ReadCommentDetailQuery;
+import app.slicequeue.sq_board.comment.query.application.service.ReadCommentService;
+import app.slicequeue.sq_board.comment.query.presentation.dto.CommentDetail;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/comments")
+@RequiredArgsConstructor
+public class CommentQueryController {
+
+    private final ReadCommentService readCommentService;
+
+    @GetMapping("/{commentId}")
+    public CommonResponse<CommentDetail> read(@PathVariable("commentId") Long id) {
+        ReadCommentDetailQuery query = ReadCommentDetailQuery.from(id);
+        return CommonResponse.success(readCommentService.read(query));
+    }
+
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/query/presentation/dto/CommentDetail.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/query/presentation/dto/CommentDetail.java
@@ -1,0 +1,31 @@
+package app.slicequeue.sq_board.comment.query.presentation.dto;
+
+import app.slicequeue.sq_board.comment.command.domain.Comment;
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+public class CommentDetail {
+
+    private String commentId;
+    private String content;
+    private String articleId;
+    private String parentCommentId;
+    private String writerId;
+    private String writerNickname;
+    private String commentPath;
+
+    public static CommentDetail from(Comment comment) {
+        CommentDetail detail = new CommentDetail();
+        detail.commentId = comment.getCommentId().toString();
+        detail.content = comment.getContent();
+        detail.articleId = comment.getArticleId().toString();
+        detail.parentCommentId = Objects.nonNull(comment.getParentCommentId())
+                ? comment.getParentCommentId().toString() : null;
+        detail.writerId = comment.getWriterId().toString();
+        detail.writerNickname = comment.getWriterNickname();
+        detail.commentPath = comment.getPath().toString();
+        return detail;
+    }
+}


### PR DESCRIPTION
## ✨ 주요 변경 사항
1. **`JpaBoardQueryRepository`**: `@Transactional(readOnly = true)` 어노테이션 추가로 읽기 전용 트랜잭션 설정.  
2. **`ReadCommentDetailQuery`**: 댓글 상세 조회를 위한 Query 객체 추가 및 `from(Long id)` 메서드를 통해 `CommentId` 객체 생성.  
3. **`ReadCommentService`**: 댓글 상세 정보를 조회하는 서비스 클래스 추가, `JpaCommentQueryRepository`를 사용하며 존재하지 않을 경우 `NotFoundException` 발생.  
4. **`JpaCommentQueryRepository`**: `Comment` 엔티티와 연동된 JPA Repository 인터페이스 추가, 읽기 전용 트랜잭션 보장.  
5. **`CommentQueryController`**: `/v1/comments/{commentId}` 경로로 댓글 상세 조회 API를 제공하는 컨트롤러 추가.  
6. **`CommentDetail` DTO**: 댓글 상세 정보 응답을 위한 DTO 클래스 추가, `from(Comment comment)` 메서드를 통해 `Comment` 엔티티를 DTO로 변환.  

## 🚀 적용 방법
1. 클라이언트에서 페이지 번호와 데이터 수를 포함한 요청을 전송합니다.
2. 해당 API 엔드포인트를 호출하여 필요한 데이터만 페이지 단위로 받아옵니다.
3. 클라이언트에서 받은 데이터를 화면에 렌더링하여 페이징 UI를 구성합니다.

## ✅ 체크리스트
- [ ] API 엔드포인트가 정상적으로 호출되는지 확인
- [ ] 페이징 로직이 정확히 작동하는지 테스트
- [ ] 다양한 페이지 요청 시 데이터가 올바르게 반환되는지 검증
- [ ] 관련 코드가 코드 리뷰 기준에 부합하는지 확인
