### PR TITLE
[COMMENT] 댓글 생성시 삭제 된 댓글이 있는 경우 parentPath 중복 오류 수정

### DIFF
--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/CreateCommentService.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/CreateCommentService.java
@@ -22,8 +22,11 @@ public class CreateCommentService {
 
         Comment comment = Comment.create(command,
                 parentCommentPath.createChildCommentPath(
-                        commentRepository.findDescendantsTopPath(command.articleId(),
-                                parentCommentPath.getPath()).orElse(null))
+                        commentRepository.findDescendantsTopPath(
+                                command.articleId().getId(),
+                                parentCommentPath.getPath())
+                                .map(CommentPath::create)
+                                .orElse(null))
         );
         return commentRepository.save(comment).getCommentId();
     }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/CommentRepository.java
@@ -1,6 +1,5 @@
 package app.slicequeue.sq_board.comment.command.domain;
 
-import app.slicequeue.sq_board.article.command.domain.ArticleId;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -15,6 +14,6 @@ public interface CommentRepository {
 
     Optional<Comment> findByPath(CommentPath path);
 
-    Optional<CommentPath> findDescendantsTopPath(@Param("articleId") ArticleId articleId,
+    Optional<String> findDescendantsTopPath(@Param("articleId") Long articleId,
                                                @Param("pathPrefix") String pathPrefix);
 }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/infra/JpaCommentRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/infra/JpaCommentRepository.java
@@ -1,6 +1,5 @@
 package app.slicequeue.sq_board.comment.command.infra;
 
-import app.slicequeue.sq_board.article.command.domain.ArticleId;
 import app.slicequeue.sq_board.comment.command.domain.Comment;
 import app.slicequeue.sq_board.comment.command.domain.CommentId;
 import app.slicequeue.sq_board.comment.command.domain.CommentPath;
@@ -19,13 +18,16 @@ public interface JpaCommentRepository extends JpaRepository<Comment, CommentId>,
 
     Optional<Comment> findByPath(CommentPath path);
 
-    @Query("""
-            select c.path from Comment c
-            where c.articleId = :articleId
-            and c.path.path > :pathPrefix and c.path.path like :pathPrefix%
-            order by path.path desc limit 1
-            """)
-    Optional<CommentPath> findDescendantsTopPath(
-            @Param("articleId") ArticleId articleId,
+    @Query(value = """
+            SELECT c.path
+            FROM comment c
+            WHERE c.article_id = :articleId
+              AND c.path > :pathPrefix
+              AND c.path LIKE CONCAT(:pathPrefix, '%')
+            ORDER BY c.path DESC
+            LIMIT 1
+            """, nativeQuery = true)
+    Optional<String> findDescendantsTopPath(
+            @Param("articleId") Long articleId,
             @Param("pathPrefix") String pathPrefix);
 }


### PR DESCRIPTION
## 🛠️ 목적
댓글 생성시 삭제 된 댓글이 있는 경우 parentPath 중복 오류 수정 합니다.

## 📄 내용 요약
- 원인: 삭제된 것 제외하는 @SQLRestriction("deleted IS FALSE") 조건 적용되어 하위 위치 판정 댓글 못찾음
- 해결: 네이티브 쿼리 사용하여 조회 원하는 결과 나오도록 수정