### PR TITLE
[COMMON] BoardId 관련 from 생성시 생성자 못찾는 에러 수정

### DIFF
--- a/src/main/java/app/slicequeue/sq_board/board/command/domain/BoardId.java
+++ b/src/main/java/app/slicequeue/sq_board/board/command/domain/BoardId.java
@@ -2,15 +2,9 @@ package app.slicequeue.sq_board.board.command.domain;
 
 import app.slicequeue.common.base.id_entity.BaseSnowflakeId;
 import app.slicequeue.common.snowflake.Snowflake;
-import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Comment;
-import org.springframework.util.Assert;
-
-import java.util.Objects;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
@@ -18,7 +12,8 @@ public class BoardId extends BaseSnowflakeId<BoardId> {
 
     static Snowflake snowflake = new Snowflake();
 
-    private BoardId(long id) {super(id);
+    public BoardId(Long id) {
+        super(id);
     }
 
     @Override


### PR DESCRIPTION
## 📄 내용 요약
- 원인: 상위 BaseSnowflakeId 의 from 에서 BoardId 누락된 생성자 확인되어 생성자 찾을 수 있도록 기존 생성자 수정