### PR TITLE
[COMMENT-COUNT] 게시글 댓글 카운트 증감 처리 적용

### DIFF
--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/service/CreateCommentService.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/service/CreateCommentService.java
@@ -1,4 +1,4 @@
-package app.slicequeue.sq_board.comment.command.application;
+package app.slicequeue.sq_board.comment.command.application.service;
 
 import app.slicequeue.sq_board.comment.command.domain.Comment;
 import app.slicequeue.sq_board.comment.command.domain.CommentId;
@@ -16,7 +16,7 @@ public class CreateCommentService {
 
     private final CommentRepository commentRepository;
 
-    public CommentId createComment(CreateCommentCommand command) {
+    public Comment createComment(CreateCommentCommand command) {
         Comment parent = findParent(command);
         CommentPath parentCommentPath = parent == null ? CommentPath.create("") : parent.getPath();
 
@@ -28,7 +28,7 @@ public class CreateCommentService {
                                 .map(CommentPath::create)
                                 .orElse(null))
         );
-        return commentRepository.save(comment).getCommentId();
+        return commentRepository.save(comment);
     }
 
     private Comment findParent(CreateCommentCommand command) {

--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/service/DeleteCommentService.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/service/DeleteCommentService.java
@@ -1,4 +1,4 @@
-package app.slicequeue.sq_board.comment.command.application;
+package app.slicequeue.sq_board.comment.command.application.service;
 
 import app.slicequeue.common.exception.NotFoundException;
 import app.slicequeue.sq_board.comment.command.domain.Comment;
@@ -17,10 +17,10 @@ public class DeleteCommentService {
 
     private final CommentRepository commentRepository;
 
-    public CommentId deleteComment(DeleteCommentCommand command) {
+    public Comment deleteComment(DeleteCommentCommand command) {
         Comment comment = commentRepository.findByCommentId(command.commentId())
                 .orElseThrow(() -> new NotFoundException("댓글을 찾을 수가 없습니다."));
         comment.delete();
-        return commentRepository.save(comment).getCommentId();
+        return commentRepository.save(comment);
     }
 }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/service/SummarizeArticleCommentCountService.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/service/SummarizeArticleCommentCountService.java
@@ -1,0 +1,40 @@
+package app.slicequeue.sq_board.comment.command.application.service;
+
+import app.slicequeue.sq_board.comment.command.domain.ArticleCommentCount;
+import app.slicequeue.sq_board.comment.command.domain.ArticleCommentCountRepository;
+import app.slicequeue.sq_board.comment.command.domain.Comment;
+import app.slicequeue.sq_board.comment.command.domain.dto.ArticleCommentCountCommand;
+import app.slicequeue.sq_board.common.callback.LockedReturnCallback;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SummarizeArticleCommentCountService {
+
+    private final ArticleCommentCountRepository articleCommentCountRepository;
+
+    @Transactional
+    public void increaseWithLock(LockedReturnCallback<Comment> callback) {
+        ArticleCommentCountCommand command = ArticleCommentCountCommand.from(callback.execute());
+        ArticleCommentCount articleCommentCount =
+                articleCommentCountRepository
+                        .findLockedByArticleId(command.articleId())
+                        .orElse(ArticleCommentCount.createCountZero(command));
+        articleCommentCount.increaseCount(command.lastCreatedAt());
+        articleCommentCountRepository.save(articleCommentCount);
+    }
+
+    @Transactional
+    public void decreaseWithLock(LockedReturnCallback<Comment> callback) {
+        Comment comment = callback.execute();
+        ArticleCommentCountCommand command = ArticleCommentCountCommand.from(comment);
+        ArticleCommentCount articleCommentCount =
+                articleCommentCountRepository
+                        .findLockedByArticleId(comment.getArticleId())
+                        .orElse(ArticleCommentCount.createCountZero(command));
+        articleCommentCount.decreaseCount();
+        articleCommentCountRepository.save(articleCommentCount);
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/service/UpdateCommentService.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/service/UpdateCommentService.java
@@ -1,4 +1,4 @@
-package app.slicequeue.sq_board.comment.command.application;
+package app.slicequeue.sq_board.comment.command.application.service;
 
 import app.slicequeue.common.exception.NotFoundException;
 import app.slicequeue.sq_board.comment.command.domain.Comment;
@@ -18,10 +18,10 @@ public class UpdateCommentService {
 
     private final CommentRepository commentRepository;
 
-    public CommentId updateComment(UpdateCommentCommand command) {
+    public Comment updateComment(UpdateCommentCommand command) {
         Comment comment = commentRepository.findByCommentId(command.commentId())
                 .orElseThrow(() -> new NotFoundException("댓글을 찾을 수가 없습니다."));
         comment.update(command);
-        return commentRepository.save(comment).getCommentId();
+        return commentRepository.save(comment);
     }
 }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/usecase/CreateCommentUseCase.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/usecase/CreateCommentUseCase.java
@@ -1,0 +1,49 @@
+package app.slicequeue.sq_board.comment.command.application.usecase;
+
+import app.slicequeue.common.exception.NotFoundException;
+import app.slicequeue.sq_board.comment.command.application.service.CreateCommentService;
+import app.slicequeue.sq_board.comment.command.application.service.SummarizeArticleCommentCountService;
+import app.slicequeue.sq_board.comment.command.domain.Comment;
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+import app.slicequeue.sq_board.comment.command.domain.dto.ArticleCommentCountCommand;
+import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
+import app.slicequeue.sq_board.common.util.ConstraintViolationUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+@Service
+@RequiredArgsConstructor
+public class CreateCommentUseCase {
+
+    private final CreateCommentService createCommentService;
+    private final SummarizeArticleCommentCountService summarizeArticleCommentCountService;
+
+    public CommentId execute(CreateCommentCommand command) {
+        try {
+            return executeWithTransaction(command);
+        } catch (
+                DataIntegrityViolationException e) {
+            if (ConstraintViolationUtils.isForeignKeyViolation(e)) {
+                throw new NotFoundException("존재하지 않는 게시글입니다.");
+            }
+            throw e;
+        }
+    }
+
+    @Transactional
+    private CommentId executeWithTransaction(CreateCommentCommand command) {
+        AtomicReference<Comment> comment = new AtomicReference<>();
+        summarizeArticleCommentCountService.increaseWithLock(
+                () -> {
+                    Comment created = createCommentService.createComment(command);
+                    comment.set(created);
+                    return created;
+                });
+        return comment.get().getCommentId();
+    }
+
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/usecase/DeleteCommentUseCase.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/usecase/DeleteCommentUseCase.java
@@ -1,0 +1,50 @@
+package app.slicequeue.sq_board.comment.command.application.usecase;
+
+import app.slicequeue.common.exception.NotFoundException;
+import app.slicequeue.sq_board.comment.command.application.service.DeleteCommentService;
+import app.slicequeue.sq_board.comment.command.application.service.SummarizeArticleCommentCountService;
+import app.slicequeue.sq_board.comment.command.domain.Comment;
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+import app.slicequeue.sq_board.comment.command.domain.dto.ArticleCommentCountCommand;
+import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
+import app.slicequeue.sq_board.comment.command.domain.dto.DeleteCommentCommand;
+import app.slicequeue.sq_board.common.util.ConstraintViolationUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteCommentUseCase {
+
+    private final DeleteCommentService deleteCommentService;
+    private final SummarizeArticleCommentCountService summarizeArticleCommentCountService;
+
+    public CommentId execute(DeleteCommentCommand command) {
+        try {
+            return executeWithTransaction(command);
+        } catch (
+                DataIntegrityViolationException e) {
+            if (ConstraintViolationUtils.isForeignKeyViolation(e)) {
+                throw new NotFoundException("존재하지 않는 게시글입니다.");
+            }
+            throw e;
+        }
+    }
+
+    @Transactional
+    private CommentId executeWithTransaction(DeleteCommentCommand command) {
+        AtomicReference<Comment> comment = new AtomicReference<>();
+        summarizeArticleCommentCountService.decreaseWithLock(
+                () -> {
+                    Comment deleted = deleteCommentService.deleteComment(command);
+                    comment.set(deleted);
+                    return deleted;
+                });
+        return comment.get().getCommentId();
+    }
+
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/application/usecase/UpdateCommentUseCase.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/application/usecase/UpdateCommentUseCase.java
@@ -1,0 +1,42 @@
+package app.slicequeue.sq_board.comment.command.application.usecase;
+
+import app.slicequeue.common.exception.NotFoundException;
+import app.slicequeue.sq_board.comment.command.application.service.UpdateCommentService;
+import app.slicequeue.sq_board.comment.command.domain.Comment;
+import app.slicequeue.sq_board.comment.command.domain.CommentId;
+import app.slicequeue.sq_board.comment.command.domain.dto.ArticleCommentCountCommand;
+import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
+import app.slicequeue.sq_board.comment.command.domain.dto.UpdateCommentCommand;
+import app.slicequeue.sq_board.common.util.ConstraintViolationUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateCommentUseCase {
+
+    private final UpdateCommentService updateCommentService;
+
+    public CommentId execute(UpdateCommentCommand command) {
+        try {
+            return executeWithTransaction(command);
+        } catch (
+                DataIntegrityViolationException e) {
+            if (ConstraintViolationUtils.isForeignKeyViolation(e)) {
+                throw new NotFoundException("존재하지 않는 게시글입니다.");
+            }
+            throw e;
+        }
+    }
+
+    @Transactional
+    private CommentId executeWithTransaction(UpdateCommentCommand command) {
+        Comment comment = updateCommentService.updateComment(command);
+        return comment.getCommentId();
+    }
+
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/ArticleCommentCount.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/ArticleCommentCount.java
@@ -1,6 +1,7 @@
 package app.slicequeue.sq_board.comment.command.domain;
 
 import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import app.slicequeue.sq_board.comment.command.domain.dto.ArticleCommentCountCommand;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,4 +21,21 @@ public class ArticleCommentCount {
     private long commentCount;
     private Instant lastCreatedAt;
 
+    public static ArticleCommentCount createCountZero(ArticleCommentCountCommand command) {
+        ArticleCommentCount articleCommentCount = new ArticleCommentCount();
+        articleCommentCount.articleId = command.articleId();
+        articleCommentCount.commentCount = 0;
+        articleCommentCount.lastCreatedAt = Instant.now();
+        return articleCommentCount;
+    }
+
+    public void increaseCount(Instant commentLastCreatedAt) {
+        commentCount = commentCount + 1;
+        lastCreatedAt = commentLastCreatedAt;
+    }
+
+    public void decreaseCount() {
+        if (commentCount == 0) return;
+        commentCount = commentCount - 1;
+    }
 }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/ArticleCommentCount.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/ArticleCommentCount.java
@@ -1,0 +1,23 @@
+package app.slicequeue.sq_board.comment.command.domain;
+
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@Table(name = "article_comment_count")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleCommentCount {
+
+    @EmbeddedId
+    @AttributeOverride(name = "id", column = @Column(name = "article_id"))
+    private ArticleId articleId;
+    private long commentCount;
+    private Instant lastCreatedAt;
+
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/ArticleCommentCountRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/ArticleCommentCountRepository.java
@@ -1,8 +1,17 @@
 package app.slicequeue.sq_board.comment.command.domain;
 
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ArticleCommentCountRepository {
 
+    ArticleCommentCount save(ArticleCommentCount articleCommentCount);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<ArticleCommentCount> findLockedByArticleId(ArticleId articleId);
 }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/ArticleCommentCountRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/ArticleCommentCountRepository.java
@@ -1,0 +1,8 @@
+package app.slicequeue.sq_board.comment.command.domain;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArticleCommentCountRepository {
+
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/domain/dto/ArticleCommentCountCommand.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/domain/dto/ArticleCommentCountCommand.java
@@ -1,0 +1,17 @@
+package app.slicequeue.sq_board.comment.command.domain.dto;
+
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import app.slicequeue.sq_board.comment.command.domain.Comment;
+
+import java.time.Instant;
+
+public record ArticleCommentCountCommand(ArticleId articleId, Instant lastCreatedAt) {
+
+    public static ArticleCommentCountCommand from(Comment comment) {
+        return new ArticleCommentCountCommand(comment.getArticleId(), comment.getCreatedAt());
+    }
+
+    public static ArticleCommentCountCommand from(CreateCommentCommand command) {
+        return new ArticleCommentCountCommand(command.articleId(), null);
+    }
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/infra/JpaArticleCommentCountRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/infra/JpaArticleCommentCountRepository.java
@@ -1,9 +1,19 @@
 package app.slicequeue.sq_board.comment.command.infra;
 
+import app.slicequeue.sq_board.article.command.domain.ArticleId;
+import app.slicequeue.sq_board.comment.command.domain.ArticleCommentCount;
 import app.slicequeue.sq_board.comment.command.domain.ArticleCommentCountRepository;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface JpaArticleCommentCountRepository extends ArticleCommentCountRepository {
+import java.util.Optional;
 
+@Repository
+public interface JpaArticleCommentCountRepository extends ArticleCommentCountRepository,
+        JpaRepository<ArticleCommentCount, ArticleId> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<ArticleCommentCount> findLockedByArticleId(ArticleId articleId);
 }

--- a/src/main/java/app/slicequeue/sq_board/comment/command/infra/JpaArticleCommentCountRepository.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/infra/JpaArticleCommentCountRepository.java
@@ -1,0 +1,9 @@
+package app.slicequeue.sq_board.comment.command.infra;
+
+import app.slicequeue.sq_board.comment.command.domain.ArticleCommentCountRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaArticleCommentCountRepository extends ArticleCommentCountRepository {
+
+}

--- a/src/main/java/app/slicequeue/sq_board/comment/command/presentation/CommentCommandController.java
+++ b/src/main/java/app/slicequeue/sq_board/comment/command/presentation/CommentCommandController.java
@@ -1,9 +1,9 @@
 package app.slicequeue.sq_board.comment.command.presentation;
 
 import app.slicequeue.common.dto.CommonResponse;
-import app.slicequeue.sq_board.comment.command.application.CreateCommentService;
-import app.slicequeue.sq_board.comment.command.application.DeleteCommentService;
-import app.slicequeue.sq_board.comment.command.application.UpdateCommentService;
+import app.slicequeue.sq_board.comment.command.application.usecase.CreateCommentUseCase;
+import app.slicequeue.sq_board.comment.command.application.usecase.DeleteCommentUseCase;
+import app.slicequeue.sq_board.comment.command.application.usecase.UpdateCommentUseCase;
 import app.slicequeue.sq_board.comment.command.domain.CommentId;
 import app.slicequeue.sq_board.comment.command.domain.dto.CreateCommentCommand;
 import app.slicequeue.sq_board.comment.command.domain.dto.DeleteCommentCommand;
@@ -19,27 +19,27 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class CommentCommandController {
 
-    private final CreateCommentService createCommentService;
-    private final UpdateCommentService updateCommentService;
-    private final DeleteCommentService deleteCommentService;
+    private final CreateCommentUseCase createCommentUseCase;
+    private final UpdateCommentUseCase updateCommentUseCase;
+    private final DeleteCommentUseCase deleteCommentUseCase;
 
     @PostMapping
     public CommonResponse<String> create(@RequestBody @Valid CreateCommentRequest request) {
         CreateCommentCommand command = CreateCommentCommand.from(request);
-        return CommonResponse.success("created", createCommentService.createComment(command).toString());
+        return CommonResponse.success("created", createCommentUseCase.execute(command).toString());
     }
 
     @PutMapping("/{commentId}")
     public CommonResponse<String> update(@PathVariable("commentId") Long commentId,
                                          @RequestBody @Valid UpdateCommentRequest request) {
         UpdateCommentCommand command = UpdateCommentCommand.of(CommentId.from(commentId), request);
-        return CommonResponse.success("updated", updateCommentService.updateComment(command).toString());
+        return CommonResponse.success("updated", updateCommentUseCase.execute(command).toString());
     }
 
     @DeleteMapping("/{commentId}")
     public CommonResponse<String> delete(@PathVariable("commentId") Long commentId) {
         DeleteCommentCommand command = DeleteCommentCommand.from(CommentId.from(commentId));
-        return CommonResponse.success("updated", deleteCommentService.deleteComment(command).toString());
+        return CommonResponse.success("updated", deleteCommentUseCase.execute(command).toString());
     }
 
 }

--- a/src/main/resources/db/ddl/init.sql
+++ b/src/main/resources/db/ddl/init.sql
@@ -114,3 +114,13 @@ CREATE TABLE comment_reaction_count (
     FOREIGN KEY (comment_id)
     REFERENCES comment (comment_id))
 COMMENT = '댓글 리엑션 카운트 집계 - 사용자 이모지 반응 집계';
+
+CREATE TABLE article_comment_count (
+  article_id BIGINT NOT NULL,
+  comment_count BIGINT NOT NULL COMMENT '게시판 게시글 개수',
+  last_created_at DATETIME NOT NULL COMMENT '마지막 등록 일시',
+  PRIMARY KEY (article_id),
+  CONSTRAINT fk_bcc_article_id_a_article_id
+    FOREIGN KEY (article_id)
+    REFERENCES article (article_id))
+COMMENT = '게시판의 게시글 카운트 집계';


### PR DESCRIPTION
## 🛠️ 목적
댓글 카운트 증감 처리를 포함한 댓글 관리 기능을 개선하여 게시판 데이터의 정확성과 일관성을 보장합니다.

## 📄 내용 요약
- 댓글 작성, 수정, 삭제 시 댓글 카운트 증감 처리를 적용.
- 새로운 클래스와 로직을 통해 코드를 구조적으로 개선하고 유지보수를 용이하게 만듦.
- 트랜잭션 기반 데이터 처리로 일관성을 확보.

## ✨ 주요 변경 사항

1. **새로운 서비스 계층 추가**
   - `CreateCommentService`, `DeleteCommentService`, `UpdateCommentService`를 통해 댓글 관련 기능 모듈화.
   - `SummarizeArticleCommentCountService`를 통해 댓글 카운트 증감 로직 구현.

2. **유스케이스 클래스 설계**
   - `CreateCommentUseCase` 등 유스케이스 클래스 추가로 비즈니스 로직과 서비스 로직을 분리하여 코드 구조화.
   - 각 유스케이스 클래스에서 트랜잭션을 사용하여 데이터 일관성 보장.

3. **도메인 클래스 개선**
   - `ArticleCommentCount` 클래스를 통해 댓글 카운트 데이터 관리.
   - `ArticleCommentCountCommand`를 도입하여 도메인 계층과 DTO간의 데이터 흐름 명확화.

4. **데이터베이스 레이어 및 리포지토리**
   - `ArticleCommentCountRepository`를 통해 댓글 카운트를 효율적으로 관리 및 업데이트.

## 🚀 적용 방법
1. 댓글 작성, 수정, 삭제 시 관련 유스케이스 클래스를 호출.
2. 트랜잭션 내부에서 댓글 카운트 증감 로직을 실행.
3. 결과 데이터를 반환하며 UI에 렌더링.

## ✅ 체크리스트
- [x] 새로운 서비스 계층 및 유스케이스 클래스가 정상 작동하는지 검증.
- [x] 댓글 작성, 수정, 삭제 시 댓글 카운트가 정확히 변경되는지 테스트.
- [x] 코드 구조 개선으로 인한 유지보수성 및 확장성 평가.
- [x] 다양한 데이터 시나리오를 통한 안정성 테스트.